### PR TITLE
Fix the version in package.json file while GHA call image build

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -7,6 +7,9 @@ on:
       version:
         required: false
         type: string
+      commit_sha:
+        required: false
+        type: string
 
 env:
   ECR_REPOSITORY: "provider-sample-url-finder"
@@ -19,6 +22,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit_sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/publish-new-build.yml
+++ b/.github/workflows/publish-new-build.yml
@@ -26,6 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: code-check
     if: ${{ github.ref_name == 'main' && inputs.version != '' }}
+    outputs:
+      commit_sha: ${{ steps.commit-version.outputs.commit_sha }}
 
     steps:
       - name: Checkout code
@@ -46,9 +48,11 @@ jobs:
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
       - name: Commit version change
+        id: commit-version
         run: |
           git commit -am "Update version to ${{ inputs.version }}"
           git push origin main
+          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
   build-and-publish:
     needs:
@@ -61,6 +65,7 @@ jobs:
     uses: ./.github/workflows/build-docker-image.yml
     with:
       version: ${{ inputs.version }}
+      commit_sha: ${{ github.ref_name == 'main' && inputs.version != '' && needs.bump-version.outputs.commit_sha || '' }}
     secrets: inherit
 
   git-tag:
@@ -74,6 +79,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump-version.outputs.commit_sha }}
 
       - name: Create and push tag
         run: |


### PR DESCRIPTION
Issue:
The docker image doesn't contain the updated version in package.json while the image build was called by GHA.

Solution:
Pass the sha commit after the update version into staging/production jobs to pull on the right one