### PR TITLE
Add deal measurement API shell

### DIFF
--- a/url_finder/src/api/api_doc.rs
+++ b/url_finder/src/api/api_doc.rs
@@ -1,9 +1,23 @@
 use crate::api_response::ErrorResponse;
-use utoipa::OpenApi;
+use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
+use utoipa::{Modify, OpenApi};
 
 use crate::api::deals::*;
 use crate::api::providers::*;
 use crate::api::*;
+
+#[allow(dead_code)]
+struct SecurityAddon;
+
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        if let Some(components) = openapi.components.as_mut() {
+            let scheme =
+                SecurityScheme::Http(HttpBuilder::new().scheme(HttpAuthScheme::Bearer).build());
+            components.add_security_scheme("bearer_auth", scheme);
+        }
+    }
+}
 
 #[derive(OpenApi)]
 #[openapi(
@@ -126,6 +140,7 @@ The `/url/*` endpoints remain fully backward compatible.
         (name = "Deals", description = "PoRep V2 deal measurement API contract"),
         (name = "URL", description = "Legacy URL Finder APIs"),
         (name = "Healthcheck", description = "Health check endpoints"),
-    )
+    ),
+    modifiers(&SecurityAddon),
 )]
 pub struct ApiDoc;

--- a/url_finder/src/api/api_doc.rs
+++ b/url_finder/src/api/api_doc.rs
@@ -1,6 +1,7 @@
 use crate::api_response::ErrorResponse;
 use utoipa::OpenApi;
 
+use crate::api::deals::*;
 use crate::api::providers::*;
 use crate::api::*;
 
@@ -51,6 +52,10 @@ The `/url/*` endpoints remain fully backward compatible.
         handle_reset_provider,
         handle_history_retrievability,
         handle_history_retrievability_client,
+        // Deal measurement shell API
+        handle_upsert_deal,
+        handle_get_deal,
+        handle_get_latest,
     ),
     components(
         schemas(
@@ -96,6 +101,16 @@ The `/url/*` endpoints remain fully backward compatible.
             DiagnosticsResponse,
             ScheduleStateResponse,
             SchedulingResponse,
+            // Deal measurement shell API
+            DealPath,
+            DealVersion,
+            MeasurementState,
+            DealSliRequirements,
+            DealPieceTarget,
+            DealTargetUpsertRequest,
+            DealTargetResponse,
+            DealPerformanceResponse,
+            DealLatestMeasurementResponse,
 
             // Misc
             HealthcheckResponse,
@@ -108,6 +123,7 @@ The `/url/*` endpoints remain fully backward compatible.
     tags(
         (name = "Providers", description = "New Providers API - pre-computed data with performance metrics"),
         (name = "Clients", description = "Client endpoints - providers for a specific client"),
+        (name = "Deals", description = "PoRep V2 deal measurement API contract"),
         (name = "URL", description = "Legacy URL Finder APIs"),
         (name = "Healthcheck", description = "Health check endpoints"),
     )

--- a/url_finder/src/api/deals/get_deal.rs
+++ b/url_finder/src/api/deals/get_deal.rs
@@ -1,0 +1,23 @@
+use axum::{debug_handler, extract::Path};
+use axum_extra::extract::WithRejection;
+
+use super::{DealPath, DealTargetResponse};
+use crate::api_response::{ApiResponse, ErrorResponse, ok_response};
+
+#[utoipa::path(
+    get,
+    path = "/deals/{deal_id}",
+    description = "Contract shell for oracle-service integration. This route returns the documented response shape, but deal target persistence and measurement execution are not implemented in this slice.",
+    params(DealPath),
+    responses(
+        (status = 200, description = "Deal target placeholder", body = DealTargetResponse),
+        (status = 400, description = "Invalid path", body = ErrorResponse),
+    ),
+    tags = ["Deals"],
+)]
+#[debug_handler]
+pub async fn handle_get_deal(
+    WithRejection(Path(path), _): WithRejection<Path<DealPath>, ApiResponse<ErrorResponse>>,
+) -> Result<ApiResponse<DealTargetResponse>, ApiResponse<()>> {
+    Ok(ok_response(DealTargetResponse::placeholder(path.deal_id)))
+}

--- a/url_finder/src/api/deals/get_latest.rs
+++ b/url_finder/src/api/deals/get_latest.rs
@@ -1,0 +1,25 @@
+use axum::{debug_handler, extract::Path};
+use axum_extra::extract::WithRejection;
+
+use super::{DealLatestMeasurementResponse, DealPath};
+use crate::api_response::{ApiResponse, ErrorResponse, ok_response};
+
+#[utoipa::path(
+    get,
+    path = "/deals/{deal_id}/latest",
+    description = "Contract shell for oracle-service integration. This route returns the documented response shape, but deal target persistence and measurement execution are not implemented in this slice.",
+    params(DealPath),
+    responses(
+        (status = 200, description = "Latest deal measurement shell response", body = DealLatestMeasurementResponse),
+        (status = 400, description = "Invalid path", body = ErrorResponse),
+    ),
+    tags = ["Deals"],
+)]
+#[debug_handler]
+pub async fn handle_get_latest(
+    WithRejection(Path(path), _): WithRejection<Path<DealPath>, ApiResponse<ErrorResponse>>,
+) -> Result<ApiResponse<DealLatestMeasurementResponse>, ApiResponse<()>> {
+    Ok(ok_response(DealLatestMeasurementResponse::missing(
+        path.deal_id,
+    )))
+}

--- a/url_finder/src/api/deals/mod.rs
+++ b/url_finder/src/api/deals/mod.rs
@@ -1,0 +1,9 @@
+mod get_deal;
+mod get_latest;
+mod types;
+mod upsert_deal;
+
+pub use get_deal::*;
+pub use get_latest::*;
+pub use types::*;
+pub use upsert_deal::*;

--- a/url_finder/src/api/deals/types.rs
+++ b/url_finder/src/api/deals/types.rs
@@ -13,9 +13,10 @@ pub struct DealPath {
     pub deal_id: String,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum DealVersion {
+    #[default]
     V2,
 }
 
@@ -109,12 +110,6 @@ pub struct DealLatestMeasurementResponse {
     pub failed_count: u32,
     #[serde(default)]
     pub performance: DealPerformanceResponse,
-}
-
-impl Default for DealVersion {
-    fn default() -> Self {
-        Self::V2
-    }
 }
 
 impl DealTargetResponse {

--- a/url_finder/src/api/deals/types.rs
+++ b/url_finder/src/api/deals/types.rs
@@ -1,0 +1,263 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
+
+use crate::{
+    api::providers::{BandwidthTestResponse, GeolocationTestResponse},
+    types::{ErrorCode as UrlErrorCode, ResultCode},
+};
+
+#[derive(Debug, Clone, Deserialize, ToSchema, IntoParams)]
+pub struct DealPath {
+    #[param(value_type = String)]
+    pub deal_id: String,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum DealVersion {
+    V2,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MeasurementState {
+    Missing,
+    Fresh,
+    Stale,
+    Failed,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DealSliRequirements {
+    pub retrievability_bps: u16,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bandwidth_mbps: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DealPieceTarget {
+    pub piece_cid: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub piece_size_bytes: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allocation_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub claim_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DealTargetUpsertRequest {
+    #[serde(default)]
+    pub deal_version: DealVersion,
+    pub provider_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest_location: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_size_bytes: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requirements: Option<DealSliRequirements>,
+    #[serde(default)]
+    pub pieces: Vec<DealPieceTarget>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DealTargetResponse {
+    pub deal_id: String,
+    pub deal_version: DealVersion,
+    pub provider_id: Option<String>,
+    pub client: Option<String>,
+    pub manifest_hash: Option<String>,
+    pub manifest_location: Option<String>,
+    pub requested_size_bytes: Option<String>,
+    pub requirements: Option<DealSliRequirements>,
+    #[serde(default)]
+    pub pieces: Vec<DealPieceTarget>,
+    pub created_at: Option<DateTime<Utc>>,
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
+pub struct DealPerformanceResponse {
+    pub bandwidth: Option<BandwidthTestResponse>,
+    pub geolocation: Option<GeolocationTestResponse>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DealLatestMeasurementResponse {
+    pub deal_id: String,
+    pub measurement_state: MeasurementState,
+    pub tested_at: Option<DateTime<Utc>>,
+    pub working_url: Option<String>,
+    pub retrievability_percent: Option<f64>,
+    pub large_files_percent: Option<f64>,
+    pub car_files_percent: Option<f64>,
+    pub sector_utilization_percent: Option<f64>,
+    pub is_consistent: Option<bool>,
+    pub is_reliable: Option<bool>,
+    pub result_code: Option<ResultCode>,
+    pub error_code: Option<UrlErrorCode>,
+    pub piece_count: u32,
+    pub success_count: u32,
+    pub failed_count: u32,
+    #[serde(default)]
+    pub performance: DealPerformanceResponse,
+}
+
+impl Default for DealVersion {
+    fn default() -> Self {
+        Self::V2
+    }
+}
+
+impl DealTargetResponse {
+    pub fn placeholder(deal_id: String) -> Self {
+        Self {
+            deal_id,
+            deal_version: DealVersion::V2,
+            provider_id: None,
+            client: None,
+            manifest_hash: None,
+            manifest_location: None,
+            requested_size_bytes: None,
+            requirements: None,
+            pieces: Vec::new(),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    pub fn from_upsert_request(deal_id: String, request: DealTargetUpsertRequest) -> Self {
+        Self {
+            deal_id,
+            deal_version: request.deal_version,
+            provider_id: Some(request.provider_id),
+            client: request.client,
+            manifest_hash: request.manifest_hash,
+            manifest_location: request.manifest_location,
+            requested_size_bytes: request.requested_size_bytes,
+            requirements: request.requirements,
+            pieces: request.pieces,
+            created_at: None,
+            updated_at: None,
+        }
+    }
+}
+
+impl DealLatestMeasurementResponse {
+    pub fn missing(deal_id: String) -> Self {
+        Self {
+            deal_id,
+            measurement_state: MeasurementState::Missing,
+            tested_at: None,
+            working_url: None,
+            retrievability_percent: None,
+            large_files_percent: None,
+            car_files_percent: None,
+            sector_utilization_percent: None,
+            is_consistent: None,
+            is_reliable: None,
+            result_code: None,
+            error_code: None,
+            piece_count: 0,
+            success_count: 0,
+            failed_count: 0,
+            performance: DealPerformanceResponse::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn serializes_upsert_request_with_snake_case_fields() {
+        let request = DealTargetUpsertRequest {
+            deal_version: DealVersion::V2,
+            provider_id: "f01234".to_string(),
+            client: Some("f05678".to_string()),
+            manifest_hash: Some("bafy-manifest".to_string()),
+            manifest_location: Some("https://example.com/manifest.car".to_string()),
+            requested_size_bytes: Some("2048".to_string()),
+            requirements: Some(DealSliRequirements {
+                retrievability_bps: 9_500,
+                bandwidth_mbps: Some(200),
+                latency_ms: Some(150),
+            }),
+            pieces: vec![DealPieceTarget {
+                piece_cid: "baga6ea4seaq".to_string(),
+                piece_size_bytes: Some("1024".to_string()),
+                allocation_id: Some("44".to_string()),
+                claim_id: Some("55".to_string()),
+            }],
+        };
+
+        let value = serde_json::to_value(request).expect("request should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "deal_version": "v2",
+                "provider_id": "f01234",
+                "client": "f05678",
+                "manifest_hash": "bafy-manifest",
+                "manifest_location": "https://example.com/manifest.car",
+                "requested_size_bytes": "2048",
+                "requirements": {
+                    "retrievability_bps": 9500,
+                    "bandwidth_mbps": 200,
+                    "latency_ms": 150
+                },
+                "pieces": [{
+                    "piece_cid": "baga6ea4seaq",
+                    "piece_size_bytes": "1024",
+                    "allocation_id": "44",
+                    "claim_id": "55"
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn serializes_latest_placeholder_with_missing_state() {
+        let value = serde_json::to_value(DealLatestMeasurementResponse::missing(
+            "12345678901234567890".to_string(),
+        ))
+        .expect("latest shell response should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "deal_id": "12345678901234567890",
+                "measurement_state": "missing",
+                "tested_at": null,
+                "working_url": null,
+                "retrievability_percent": null,
+                "large_files_percent": null,
+                "car_files_percent": null,
+                "sector_utilization_percent": null,
+                "is_consistent": null,
+                "is_reliable": null,
+                "result_code": null,
+                "error_code": null,
+                "piece_count": 0,
+                "success_count": 0,
+                "failed_count": 0,
+                "performance": {
+                    "bandwidth": null,
+                    "geolocation": null
+                }
+            })
+        );
+    }
+}

--- a/url_finder/src/api/deals/upsert_deal.rs
+++ b/url_finder/src/api/deals/upsert_deal.rs
@@ -1,0 +1,31 @@
+use axum::{Json, debug_handler, extract::Path};
+use axum_extra::extract::WithRejection;
+
+use super::{DealPath, DealTargetResponse, DealTargetUpsertRequest};
+use crate::api_response::{ApiResponse, ErrorResponse, ok_response};
+
+#[utoipa::path(
+    put,
+    path = "/deals/{deal_id}",
+    description = "Contract shell for oracle-service integration. This route returns the documented response shape, but deal target persistence and measurement execution are not implemented in this slice.",
+    request_body = DealTargetUpsertRequest,
+    params(DealPath),
+    responses(
+        (status = 200, description = "Deal target shell response", body = DealTargetResponse),
+        (status = 400, description = "Invalid path or request body", body = ErrorResponse),
+    ),
+    tags = ["Deals"],
+)]
+#[debug_handler]
+pub async fn handle_upsert_deal(
+    WithRejection(Path(path), _): WithRejection<Path<DealPath>, ApiResponse<ErrorResponse>>,
+    WithRejection(Json(request), _): WithRejection<
+        Json<DealTargetUpsertRequest>,
+        ApiResponse<ErrorResponse>,
+    >,
+) -> Result<ApiResponse<DealTargetResponse>, ApiResponse<()>> {
+    Ok(ok_response(DealTargetResponse::from_upsert_request(
+        path.deal_id,
+        request,
+    )))
+}

--- a/url_finder/src/api/deals/upsert_deal.rs
+++ b/url_finder/src/api/deals/upsert_deal.rs
@@ -1,8 +1,14 @@
+use std::sync::Arc;
+
 use axum::{Json, debug_handler, extract::Path};
 use axum_extra::extract::WithRejection;
 
 use super::{DealPath, DealTargetResponse, DealTargetUpsertRequest};
-use crate::api_response::{ApiResponse, ErrorResponse, ok_response};
+use crate::{
+    AppState,
+    api_response::{ApiResponse, ErrorResponse, ok_response},
+    auth::OracleAuth,
+};
 
 #[utoipa::path(
     put,
@@ -13,11 +19,14 @@ use crate::api_response::{ApiResponse, ErrorResponse, ok_response};
     responses(
         (status = 200, description = "Deal target shell response", body = DealTargetResponse),
         (status = 400, description = "Invalid path or request body", body = ErrorResponse),
+        (status = 401, description = "Missing or invalid oracle bearer token", body = ErrorResponse),
     ),
+    security(("bearer_auth" = [])),
     tags = ["Deals"],
 )]
-#[debug_handler]
+#[debug_handler(state = Arc<AppState>)]
 pub async fn handle_upsert_deal(
+    _auth: OracleAuth,
     WithRejection(Path(path), _): WithRejection<Path<DealPath>, ApiResponse<ErrorResponse>>,
     WithRejection(Json(request), _): WithRejection<
         Json<DealTargetUpsertRequest>,

--- a/url_finder/src/api/mod.rs
+++ b/url_finder/src/api/mod.rs
@@ -22,4 +22,6 @@ pub use find_retri_sp_client::*;
 mod responses;
 pub use responses::*;
 
+pub mod deals;
+pub use deals::*;
 pub mod providers;

--- a/url_finder/src/auth.rs
+++ b/url_finder/src/auth.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::FromRequestParts,
+    http::{HeaderMap, header::AUTHORIZATION, request::Parts},
+};
+
+use crate::{
+    AppState,
+    api_response::{ApiResponse, unauthorized},
+};
+
+pub struct OracleAuth;
+
+impl FromRequestParts<Arc<AppState>> for OracleAuth {
+    type Rejection = ApiResponse<()>;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &Arc<AppState>,
+    ) -> Result<Self, Self::Rejection> {
+        if has_valid_bearer_token(&parts.headers, &state.config.auth_token) {
+            Ok(Self)
+        } else {
+            Err(unauthorized("Unauthorized"))
+        }
+    }
+}
+
+pub fn has_valid_bearer_token(headers: &HeaderMap, expected_token: &str) -> bool {
+    let Some(header) = headers.get(AUTHORIZATION) else {
+        return false;
+    };
+
+    let Ok(header) = header.to_str() else {
+        return false;
+    };
+
+    header == format!("Bearer {expected_token}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn headers_with_authorization(value: &'static str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static(value));
+        headers
+    }
+
+    #[test]
+    fn rejects_missing_authorization_header() {
+        let headers = HeaderMap::new();
+
+        assert!(!has_valid_bearer_token(&headers, "test-token"));
+    }
+
+    #[test]
+    fn rejects_wrong_bearer_token() {
+        let headers = headers_with_authorization("Bearer wrong-token");
+
+        assert!(!has_valid_bearer_token(&headers, "test-token"));
+    }
+
+    #[test]
+    fn rejects_non_bearer_authorization_header() {
+        let headers = headers_with_authorization("Basic test-token");
+
+        assert!(!has_valid_bearer_token(&headers, "test-token"));
+    }
+
+    #[test]
+    fn accepts_matching_bearer_token() {
+        let headers = headers_with_authorization("Bearer test-token");
+
+        assert!(has_valid_bearer_token(&headers, "test-token"));
+    }
+}

--- a/url_finder/src/background/url_discovery_scheduler.rs
+++ b/url_finder/src/background/url_discovery_scheduler.rs
@@ -89,11 +89,7 @@ impl DiscoveryBatchStats {
     }
 
     fn success_percent(&self) -> usize {
-        if self.total > 0 {
-            (self.ok * 100) / self.total
-        } else {
-            0
-        }
+        (self.ok * 100).checked_div(self.total).unwrap_or(0)
     }
 }
 

--- a/url_finder/src/config.rs
+++ b/url_finder/src/config.rs
@@ -17,6 +17,8 @@ pub const MIN_VALID_CONTENT_LENGTH: u64 = 8 * 1024 * 1024 * 1024; // 8GB
 // History endpoint settings
 pub const MAX_HISTORY_DAYS: i64 = 30;
 
+const DEFAULT_AUTH_TOKEN: &str = "mysecrettokenthatdefinatelyisnotongithubpublicrepo";
+
 fn parse_positive_i64_or_default(env_var: &str, default: i64) -> i64 {
     assert!(default > 0, "default must be positive");
     match env::var(env_var) {
@@ -35,6 +37,22 @@ fn parse_positive_i64_or_default(env_var: &str, default: i64) -> i64 {
     }
 }
 
+fn require_non_empty_env_value(env_var: &str, value: String) -> String {
+    assert!(!value.trim().is_empty(), "{env_var} must not be empty");
+    value
+}
+
+fn auth_token_or_default(value: Option<String>) -> String {
+    match value {
+        Some(value) => require_non_empty_env_value("AUTH_TOKEN", value),
+        None => DEFAULT_AUTH_TOKEN.to_string(),
+    }
+}
+
+fn read_auth_token() -> String {
+    auth_token_or_default(env::var("AUTH_TOKEN").ok())
+}
+
 #[derive(Debug, Clone)]
 pub struct Config {
     pub db_url: String,
@@ -48,6 +66,7 @@ pub struct Config {
     pub proxy_ip_count: Option<u32>,
     pub proxy_default_port: Option<u32>,
     pub bms_url: String,
+    pub auth_token: String,
     pub bms_default_worker_count: i64,
     pub bms_test_interval_days: i64,
     pub max_concurrent_providers: usize,
@@ -80,6 +99,7 @@ impl Config {
                 .and_then(|s| s.parse().ok()),
             proxy_ip_count: env::var("PROXY_IP_COUNT").ok().and_then(|s| s.parse().ok()),
             bms_url: env::var("BMS_URL").expect("BMS_URL must be set"),
+            auth_token: read_auth_token(),
             bms_default_worker_count: parse_positive_i64_or_default("BMS_WORKER_COUNT", 10),
             bms_test_interval_days: parse_positive_i64_or_default("BMS_TEST_INTERVAL_DAYS", 7),
             max_concurrent_providers: env::var("MAX_CONCURRENT_PROVIDERS")
@@ -104,9 +124,48 @@ impl Config {
             proxy_ip_count: None,
             proxy_default_port: None,
             bms_url: "http://localhost:8080".to_string(),
+            auth_token: "test-token".to_string(),
             bms_default_worker_count: 10,
             bms_test_interval_days: 7,
             max_concurrent_providers: 10,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DEFAULT_AUTH_TOKEN, auth_token_or_default, require_non_empty_env_value};
+
+    #[test]
+    fn accepts_non_empty_env_value() {
+        assert_eq!(
+            require_non_empty_env_value("AUTH_TOKEN", "test-token".to_string()),
+            "test-token"
+        );
+    }
+
+    #[test]
+    fn auth_token_uses_default_when_env_is_missing() {
+        assert_eq!(auth_token_or_default(None), DEFAULT_AUTH_TOKEN);
+    }
+
+    #[test]
+    fn auth_token_uses_non_empty_env_value() {
+        assert_eq!(
+            auth_token_or_default(Some("configured-token".to_string())),
+            "configured-token"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "AUTH_TOKEN must not be empty")]
+    fn rejects_empty_env_value() {
+        auth_token_or_default(Some("".to_string()));
+    }
+
+    #[test]
+    #[should_panic(expected = "AUTH_TOKEN must not be empty")]
+    fn rejects_whitespace_env_value() {
+        auth_token_or_default(Some("   ".to_string()));
     }
 }

--- a/url_finder/src/lib.rs
+++ b/url_finder/src/lib.rs
@@ -4,6 +4,7 @@ pub use std::sync::Arc;
 
 pub mod api;
 pub mod api_response;
+pub mod auth;
 pub mod background;
 pub mod bms_client;
 pub mod car_header;

--- a/url_finder/src/routes.rs
+++ b/url_finder/src/routes.rs
@@ -5,7 +5,7 @@ use axum::{
     body::Body,
     http::Response,
     response::IntoResponse,
-    routing::{get, post},
+    routing::{get, post, put},
 };
 use tower_governor::{
     GovernorError, GovernorLayer, governor::GovernorConfigBuilder,
@@ -106,6 +106,15 @@ pub fn create_routes() -> Router<Arc<AppState>> {
                 .error_handler(too_many_requests_error_handler),
         );
 
+    let deals_api_routes = Router::new()
+        .route("/deals/{deal_id}", put(deals::handle_upsert_deal))
+        .route("/deals/{deal_id}", get(deals::handle_get_deal))
+        .route("/deals/{deal_id}/latest", get(deals::handle_get_latest))
+        .layer(
+            GovernorLayer::new(governor_config.clone())
+                .error_handler(too_many_requests_error_handler),
+        );
+
     let healthcheck_route = Router::new()
         .route("/healthcheck", get(handle_healthcheck))
         .layer(
@@ -117,5 +126,6 @@ pub fn create_routes() -> Router<Arc<AppState>> {
         .merge(swagger_routes)
         .merge(legacy_api_routes)
         .merge(providers_api_routes)
+        .merge(deals_api_routes)
         .merge(healthcheck_route)
 }

--- a/url_finder/tests/integration_tests/deals_auth.rs
+++ b/url_finder/tests/integration_tests/deals_auth.rs
@@ -1,0 +1,153 @@
+use assert_json_diff::assert_json_include;
+use axum::http::StatusCode;
+use serde_json::{Value, json};
+
+use crate::common::*;
+
+fn deal_request() -> Value {
+    json!({
+        "deal_version": "v2",
+        "provider_id": "f01234",
+        "client": "f05678",
+        "manifest_hash": "bafy-manifest",
+        "manifest_location": "https://example.com/manifest.car",
+        "requested_size_bytes": "2048",
+        "requirements": {
+            "retrievability_bps": 9500,
+            "bandwidth_mbps": 200,
+            "latency_ms": 150
+        },
+        "pieces": [{
+            "piece_cid": "baga6ea4seaq",
+            "piece_size_bytes": "1024",
+            "allocation_id": "44",
+            "claim_id": "55"
+        }]
+    })
+}
+
+#[tokio::test]
+async fn test_put_deal_without_auth_returns_unauthorized() {
+    let ctx = TestContext::new().await;
+
+    let response = ctx.app.put("/deals/123").json(&deal_request()).await;
+
+    assert_eq!(response.status_code(), StatusCode::UNAUTHORIZED);
+    let body: Value = response.json();
+    assert_eq!(body, json!({ "error": "Unauthorized" }));
+}
+
+#[tokio::test]
+async fn test_put_deal_with_wrong_auth_returns_unauthorized() {
+    let ctx = TestContext::new().await;
+
+    let response = ctx
+        .app
+        .put("/deals/123")
+        .authorization_bearer("wrong-token")
+        .json(&deal_request())
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::UNAUTHORIZED);
+    let body: Value = response.json();
+    assert_eq!(body, json!({ "error": "Unauthorized" }));
+}
+
+#[tokio::test]
+async fn test_put_deal_without_auth_rejects_before_json_parsing() {
+    let ctx = TestContext::new().await;
+
+    let response = ctx
+        .app
+        .put("/deals/123")
+        .content_type("application/json")
+        .text("{")
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::UNAUTHORIZED);
+    let body: Value = response.json();
+    assert_eq!(body, json!({ "error": "Unauthorized" }));
+}
+
+#[tokio::test]
+async fn test_put_deal_with_wrong_auth_rejects_before_json_parsing() {
+    let ctx = TestContext::new().await;
+
+    let response = ctx
+        .app
+        .put("/deals/123")
+        .authorization_bearer("wrong-token")
+        .content_type("application/json")
+        .text("{")
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::UNAUTHORIZED);
+    let body: Value = response.json();
+    assert_eq!(body, json!({ "error": "Unauthorized" }));
+}
+
+#[tokio::test]
+async fn test_put_deal_with_correct_auth_returns_shell_response() {
+    let ctx = TestContext::new().await;
+
+    let response = ctx
+        .app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&deal_request())
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+    let body: Value = response.json();
+
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "deal_id": "123",
+            "deal_version": "v2",
+            "provider_id": "f01234",
+            "manifest_hash": "bafy-manifest",
+            "pieces": [{
+                "piece_cid": "baga6ea4seaq",
+                "claim_id": "55"
+            }]
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_get_deal_remains_public() {
+    let ctx = TestContext::new().await;
+
+    let response = ctx.app.get("/deals/123").await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+    let body: Value = response.json();
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "deal_id": "123",
+            "deal_version": "v2"
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_get_latest_deal_measurement_remains_public() {
+    let ctx = TestContext::new().await;
+
+    let response = ctx.app.get("/deals/123/latest").await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+    let body: Value = response.json();
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "deal_id": "123",
+            "measurement_state": "missing",
+            "piece_count": 0,
+            "success_count": 0,
+            "failed_count": 0
+        })
+    );
+}

--- a/url_finder/tests/integration_tests/mod.rs
+++ b/url_finder/tests/integration_tests/mod.rs
@@ -1,6 +1,7 @@
 pub mod bms_client;
 pub mod bms_result_repo;
 pub mod clients_providers;
+pub mod deals_auth;
 pub mod extended_response;
 pub mod find_client;
 pub mod find_retri_sp;


### PR DESCRIPTION
## Summary

Adds the initial deal measurement API shell for oracle-service integration.

Routes added:

- `PUT /deals/{deal_id}`
- `GET /deals/{deal_id}`
- `GET /deals/{deal_id}/latest`

`PUT /deals/{deal_id}` is protected with simple bearer auth.

No persistence, migrations, schedulers, BMS calls, or chain reads are added in this PR.