### PR TITLE
Implement Deal SLI persistence and manual runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,9 @@
-## Main Database
-DATABASE_URL=postgres://pguser:pgpassword@localhost:5434/sp_uf
-## DMOB Database (for local development it's the same as main database)
-DMOB_DATABASE_URL=postgres://pguser:pgpassword@localhost:5434/sp_uf
+## Writable RPA application database. Migrations and deal_sli_* writes use this DB.
+DATABASE_URL=postgres://postgres:pgpassword@localhost:5434/uf
+## Read-only DMOB deal source database. For local fake-DMOB development this may
+## point at the same local Postgres as DATABASE_URL. For mainnet-seeded testing,
+## point it at the host SSH tunnel URL and run the app with cargo on the host.
+DMOB_DATABASE_URL=postgres://postgres:pgpassword@localhost:5434/uf
 
 # URL for GLIF RPC endpoint
 GLIF_URL=https://api.node.glif.io/rpc/v1

--- a/.sqlx/query-0d508a84537342402287e6e1ee027b3240dfde57b8e0ba59ccc9bb508d30ae05.json
+++ b/.sqlx/query-0d508a84537342402287e6e1ee027b3240dfde57b8e0ba59ccc9bb508d30ae05.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n                    EXISTS (\n                        SELECT\n                            1\n                        FROM\n                            deal_sli_runs\n                        WHERE\n                            deal_id = $1\n                    ) AS \"exists!\"\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "0d508a84537342402287e6e1ee027b3240dfde57b8e0ba59ccc9bb508d30ae05"
+}

--- a/.sqlx/query-55e4b5627a5cd74a42e90ede21913a2dfffbb976ff37c1cd0319fd96e3d90225.json
+++ b/.sqlx/query-55e4b5627a5cd74a42e90ede21913a2dfffbb976ff37c1cd0319fd96e3d90225.json
@@ -1,0 +1,175 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO\n                    deal_sli_runs (\n                        deal_id,\n                        state,\n                        measurement_state,\n                        completed_at,\n                        tested_at,\n                        provider_id,\n                        client_id,\n                        working_url,\n                        retrievability_percent,\n                        large_files_percent,\n                        car_files_percent,\n                        sector_utilization_percent,\n                        is_consistent,\n                        is_reliable,\n                        result_code,\n                        piece_count,\n                        success_count,\n                        failed_count\n                    )\n               VALUES\n                    ($1, 'completed', $2, NOW(), NOW(), $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)\n               RETURNING\n                    id,\n                    deal_id,\n                    measurement_state,\n                    tested_at,\n                    working_url,\n                    retrievability_percent,\n                    large_files_percent,\n                    car_files_percent,\n                    sector_utilization_percent,\n                    is_consistent,\n                    is_reliable,\n                    result_code AS \"result_code: ResultCode\",\n                    error_code AS \"error_code: ErrorCode\",\n                    piece_count,\n                    success_count,\n                    failed_count\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "deal_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "measurement_state",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "tested_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "working_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "retrievability_percent",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 6,
+        "name": "large_files_percent",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 7,
+        "name": "car_files_percent",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 8,
+        "name": "sector_utilization_percent",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_consistent",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "is_reliable",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "result_code: ResultCode",
+        "type_info": {
+          "Custom": {
+            "name": "result_code",
+            "kind": {
+              "Enum": [
+                "NoPeerId",
+                "NoCidContactData",
+                "MissingAddrFromCidContact",
+                "MissingHttpAddrFromCidContact",
+                "FailedToGetWorkingUrl",
+                "NoDealsFound",
+                "TimedOut",
+                "Success",
+                "JobCreated",
+                "Error"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 12,
+        "name": "error_code: ErrorCode",
+        "type_info": {
+          "Custom": {
+            "name": "error_code",
+            "kind": {
+              "Enum": [
+                "NoProviderOrClient",
+                "NoProvidersFound",
+                "FailedToRetrieveCidContactData",
+                "FailedToGetPeerId",
+                "FailedToGetDeals"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 13,
+        "name": "piece_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
+        "name": "success_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_count",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Numeric",
+        "Numeric",
+        "Numeric",
+        "Numeric",
+        "Bool",
+        "Bool",
+        {
+          "Custom": {
+            "name": "result_code",
+            "kind": {
+              "Enum": [
+                "NoPeerId",
+                "NoCidContactData",
+                "MissingAddrFromCidContact",
+                "MissingHttpAddrFromCidContact",
+                "FailedToGetWorkingUrl",
+                "NoDealsFound",
+                "TimedOut",
+                "Success",
+                "JobCreated",
+                "Error"
+              ]
+            }
+          }
+        },
+        "Int4",
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "55e4b5627a5cd74a42e90ede21913a2dfffbb976ff37c1cd0319fd96e3d90225"
+}

--- a/.sqlx/query-62286a6e1b681fa0258891875fcdd50a917234bbaf7ca5291c1111c5731afbf5.json
+++ b/.sqlx/query-62286a6e1b681fa0258891875fcdd50a917234bbaf7ca5291c1111c5731afbf5.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n                    deal_id,\n                    piece_index,\n                    piece_cid,\n                    piece_size_bytes,\n                    allocation_id,\n                    claim_id\n               FROM\n                    deal_sli_pieces\n               WHERE\n                    deal_id = $1\n               ORDER BY\n                    piece_index ASC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "deal_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "piece_index",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "piece_cid",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "piece_size_bytes",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 4,
+        "name": "allocation_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "claim_id",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "62286a6e1b681fa0258891875fcdd50a917234bbaf7ca5291c1111c5731afbf5"
+}

--- a/.sqlx/query-62a42d0aba63d19d79a152808746c8655f11c5f1ce2eebc6c1ffbd90d796c97f.json
+++ b/.sqlx/query-62a42d0aba63d19d79a152808746c8655f11c5f1ce2eebc6c1ffbd90d796c97f.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT\n                    deal_id,\n                    measurement_state,\n                    tested_at,\n                    working_url,\n                    retrievability_percent,\n                    large_files_percent,\n                    car_files_percent,\n                    sector_utilization_percent,\n                    is_consistent,\n                    is_reliable,\n                    result_code AS \"result_code: ResultCode\",\n                    error_code AS \"error_code: ErrorCode\",\n                    piece_count,\n                    success_count,\n                    failed_count\n               FROM\n                    deal_sli_runs\n               WHERE\n                    deal_id = $1\n                    AND state = 'completed'\n               ORDER BY\n                    completed_at DESC NULLS LAST,\n                    started_at DESC\n               LIMIT\n                    1\n            ",
+  "query": "SELECT\n                    deal_id,\n                    measurement_state,\n                    tested_at,\n                    working_url,\n                    retrievability_percent,\n                    large_files_percent,\n                    car_files_percent,\n                    sector_utilization_percent,\n                    is_consistent,\n                    is_reliable,\n                    result_code AS \"result_code: ResultCode\",\n                    error_code AS \"error_code: ErrorCode\",\n                    piece_count,\n                    success_count,\n                    failed_count\n               FROM\n                    deal_sli_runs\n               WHERE\n                    deal_id = $1\n                    AND state = 'completed'\n               ORDER BY\n                    completed_at DESC NULLS LAST,\n                    started_at DESC,\n                    id DESC\n               LIMIT\n                    1\n            ",
   "describe": {
     "columns": [
       {
@@ -133,5 +133,5 @@
       false
     ]
   },
-  "hash": "82d41cbe1dee6039e58727b6c05b49af713f009efb4bc0ecb79bbd95a426d1d5"
+  "hash": "62a42d0aba63d19d79a152808746c8655f11c5f1ce2eebc6c1ffbd90d796c97f"
 }

--- a/.sqlx/query-7b1532c595f4e941c66160aea971362a146b4a611a4db3358ae66fc8bccc90d3.json
+++ b/.sqlx/query-7b1532c595f4e941c66160aea971362a146b4a611a4db3358ae66fc8bccc90d3.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO\n                    deal_sli_targets (\n                        deal_id,\n                        deal_version,\n                        provider_id,\n                        client_id,\n                        manifest_hash,\n                        manifest_location,\n                        retrievability_bps,\n                        bandwidth_mbps,\n                        latency_ms\n                    )\n               VALUES\n                    ($1, $2, $3, $4, $5, $6, $7, $8, $9)\n               ON CONFLICT (deal_id) DO UPDATE SET\n                    deal_version = EXCLUDED.deal_version,\n                    provider_id = EXCLUDED.provider_id,\n                    client_id = EXCLUDED.client_id,\n                    manifest_hash = EXCLUDED.manifest_hash,\n                    manifest_location = EXCLUDED.manifest_location,\n                    retrievability_bps = EXCLUDED.retrievability_bps,\n                    bandwidth_mbps = EXCLUDED.bandwidth_mbps,\n                    latency_ms = EXCLUDED.latency_ms,\n                    updated_at = NOW()\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Int4",
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7b1532c595f4e941c66160aea971362a146b4a611a4db3358ae66fc8bccc90d3"
+}

--- a/.sqlx/query-7c1997aa64b799385b72b2d6410bc34ee74b4e503fc483bb6ccb834c8bb97730.json
+++ b/.sqlx/query-7c1997aa64b799385b72b2d6410bc34ee74b4e503fc483bb6ccb834c8bb97730.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO\n                        deal_sli_piece_results (\n                            run_id,\n                            deal_id,\n                            piece_index,\n                            piece_cid,\n                            url_tested,\n                            success,\n                            content_length,\n                            is_valid_car,\n                            result_code,\n                            tested_at\n                        )\n                   VALUES\n                        ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Int4",
+        "Text",
+        "Text",
+        "Bool",
+        "Int8",
+        "Bool",
+        {
+          "Custom": {
+            "name": "result_code",
+            "kind": {
+              "Enum": [
+                "NoPeerId",
+                "NoCidContactData",
+                "MissingAddrFromCidContact",
+                "MissingHttpAddrFromCidContact",
+                "FailedToGetWorkingUrl",
+                "NoDealsFound",
+                "TimedOut",
+                "Success",
+                "JobCreated",
+                "Error"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7c1997aa64b799385b72b2d6410bc34ee74b4e503fc483bb6ccb834c8bb97730"
+}

--- a/.sqlx/query-82d41cbe1dee6039e58727b6c05b49af713f009efb4bc0ecb79bbd95a426d1d5.json
+++ b/.sqlx/query-82d41cbe1dee6039e58727b6c05b49af713f009efb4bc0ecb79bbd95a426d1d5.json
@@ -1,0 +1,137 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n                    deal_id,\n                    measurement_state,\n                    tested_at,\n                    working_url,\n                    retrievability_percent,\n                    large_files_percent,\n                    car_files_percent,\n                    sector_utilization_percent,\n                    is_consistent,\n                    is_reliable,\n                    result_code AS \"result_code: ResultCode\",\n                    error_code AS \"error_code: ErrorCode\",\n                    piece_count,\n                    success_count,\n                    failed_count\n               FROM\n                    deal_sli_runs\n               WHERE\n                    deal_id = $1\n                    AND state = 'completed'\n               ORDER BY\n                    completed_at DESC NULLS LAST,\n                    started_at DESC\n               LIMIT\n                    1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "deal_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "measurement_state",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "tested_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "working_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "retrievability_percent",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 5,
+        "name": "large_files_percent",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 6,
+        "name": "car_files_percent",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 7,
+        "name": "sector_utilization_percent",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_consistent",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_reliable",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "result_code: ResultCode",
+        "type_info": {
+          "Custom": {
+            "name": "result_code",
+            "kind": {
+              "Enum": [
+                "NoPeerId",
+                "NoCidContactData",
+                "MissingAddrFromCidContact",
+                "MissingHttpAddrFromCidContact",
+                "FailedToGetWorkingUrl",
+                "NoDealsFound",
+                "TimedOut",
+                "Success",
+                "JobCreated",
+                "Error"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 11,
+        "name": "error_code: ErrorCode",
+        "type_info": {
+          "Custom": {
+            "name": "error_code",
+            "kind": {
+              "Enum": [
+                "NoProviderOrClient",
+                "NoProvidersFound",
+                "FailedToRetrieveCidContactData",
+                "FailedToGetPeerId",
+                "FailedToGetDeals"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 12,
+        "name": "piece_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 13,
+        "name": "success_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 14,
+        "name": "failed_count",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "82d41cbe1dee6039e58727b6c05b49af713f009efb4bc0ecb79bbd95a426d1d5"
+}

--- a/.sqlx/query-872abb91ce2bbb4df61c3dbe930a896d416f52d973d856559a00b0f9407418dc.json
+++ b/.sqlx/query-872abb91ce2bbb4df61c3dbe930a896d416f52d973d856559a00b0f9407418dc.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM\n                        deal_sli_pieces\n                   WHERE\n                        deal_id = $1\n                        AND NOT (piece_index = ANY($2::int4[]))\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4Array"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "872abb91ce2bbb4df61c3dbe930a896d416f52d973d856559a00b0f9407418dc"
+}

--- a/.sqlx/query-a15906cab927e31dfe32d7331247882ca982f8bd1b7780589777e27cb4554748.json
+++ b/.sqlx/query-a15906cab927e31dfe32d7331247882ca982f8bd1b7780589777e27cb4554748.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO\n                        deal_sli_pieces (\n                            deal_id,\n                            piece_index,\n                            piece_cid,\n                            piece_size_bytes,\n                            allocation_id,\n                            claim_id\n                        )\n                   VALUES\n                        ($1, $2, $3, $4, $5, $6)\n                   ON CONFLICT (deal_id, piece_index) DO UPDATE SET\n                        piece_cid = EXCLUDED.piece_cid,\n                        piece_size_bytes = EXCLUDED.piece_size_bytes,\n                        allocation_id = EXCLUDED.allocation_id,\n                        claim_id = EXCLUDED.claim_id\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Int4",
+        "Text",
+        "Numeric",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a15906cab927e31dfe32d7331247882ca982f8bd1b7780589777e27cb4554748"
+}

--- a/.sqlx/query-c203d535cf5f178ea92e18f42e247ba03dad69376afa54bd97cc325b1e781b5f.json
+++ b/.sqlx/query-c203d535cf5f178ea92e18f42e247ba03dad69376afa54bd97cc325b1e781b5f.json
@@ -1,0 +1,82 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n                    deal_id,\n                    deal_version,\n                    provider_id,\n                    client_id,\n                    manifest_hash,\n                    manifest_location,\n                    retrievability_bps,\n                    bandwidth_mbps,\n                    latency_ms,\n                    created_at,\n                    updated_at\n               FROM\n                    deal_sli_targets\n               WHERE\n                    deal_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "deal_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "deal_version",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "provider_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "client_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "manifest_hash",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "manifest_location",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "retrievability_bps",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "bandwidth_mbps",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "latency_ms",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "c203d535cf5f178ea92e18f42e247ba03dad69376afa54bd97cc325b1e781b5f"
+}

--- a/.sqlx/query-c72440229d486b0411f73c72d8b6981a8b9da278658caad8f1ca93b3ddbedbf2.json
+++ b/.sqlx/query-c72440229d486b0411f73c72d8b6981a8b9da278658caad8f1ca93b3ddbedbf2.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n                    deal_id\n               FROM\n                    deal_sli_targets\n               WHERE\n                    deal_id = $1\n               FOR UPDATE\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "deal_id",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "c72440229d486b0411f73c72d8b6981a8b9da278658caad8f1ca93b3ddbedbf2"
+}

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ migrate-status:
 
 # Init dev environment
 init-dev: run-db
-	@until pg_isready -h localhost -p 5434 -U pguser > /dev/null 2>&1; do sleep 1; done
+	@until docker compose exec -T postgres pg_isready -U postgres -d uf > /dev/null 2>&1; do sleep 1; done
 	@$(MAKE) migrate-up init-dev-db
 # Init dev db (creates DMOB table and seeds data)
 init-dev-db:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,18 @@ The Random Piece Availability (or RPA) is a microservice designed to test the re
 
 ### Environment Variables
 
-- `DATABASE_URL` - The URL of the DMOB database
+- `DATABASE_URL` - writable RPA application database. Migrations, provider cache,
+  URL results, BMS results, and `deal_sli_*` tables use this database.
+- `DMOB_DATABASE_URL` - read-only DMOB deal source database used for deal lookup.
+  For local fake-DMOB development it may point at the same local Postgres as
+  `DATABASE_URL`. For testing against a host SSH tunnel, run Postgres in Docker
+  and run `cargo run --bin url_finder` on the host so
+  `DMOB_DATABASE_URL=postgres://...@localhost:<tunnel-port>/...` resolves
+  through the tunnel.
+
+The Docker app service is for local fake-DMOB development and points both
+database URLs at the Compose Postgres service. For SSH-tunneled DMOB testing,
+start only Postgres with `make run-db` and run the Rust binary on the host.
 
 ### Result Codes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,9 @@ services:
     command: cargo watch --poll -x 'run --bin url_finder'
     environment:
       - LOG_LEVEL=debug
-      - DATABASE_URL=${DMOB_DATABASE_URL}
+      - DATABASE_URL=postgres://postgres:pgpassword@postgres:5432/uf
+      - DMOB_DATABASE_URL=postgres://postgres:pgpassword@postgres:5432/uf
+      - BMS_URL=${BMS_URL:-https://bms.allocator.tech}
     volumes:
       - .:/app                                      # bind current directory to /app
       - /dev/null:/app/.env                         # do not use .env file

--- a/migrations/20260602120000_create_deal_sli_tables.down.sql
+++ b/migrations/20260602120000_create_deal_sli_tables.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS deal_sli_piece_results;
+DROP TABLE IF EXISTS deal_sli_runs;
+DROP TABLE IF EXISTS deal_sli_pieces;
+DROP TABLE IF EXISTS deal_sli_targets;

--- a/migrations/20260602120000_create_deal_sli_tables.up.sql
+++ b/migrations/20260602120000_create_deal_sli_tables.up.sql
@@ -1,0 +1,127 @@
+CREATE TABLE deal_sli_targets (
+    deal_id TEXT PRIMARY KEY,
+    deal_version TEXT NOT NULL DEFAULT 'v2',
+    provider_id TEXT NOT NULL,
+    client_id TEXT,
+    manifest_hash TEXT,
+    manifest_location TEXT,
+    retrievability_bps INTEGER,
+    bandwidth_mbps INTEGER,
+    latency_ms INTEGER,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT deal_sli_targets_deal_version_check CHECK (deal_version = 'v2'),
+    CONSTRAINT deal_sli_targets_deal_id_decimal_check CHECK (deal_id ~ '^[0-9]+$'),
+    CONSTRAINT deal_sli_targets_retri_bps_check CHECK (
+        retrievability_bps IS NULL
+        OR (retrievability_bps >= 0 AND retrievability_bps <= 10000)
+    ),
+    CONSTRAINT deal_sli_targets_bandwidth_check CHECK (
+        bandwidth_mbps IS NULL OR bandwidth_mbps >= 0
+    ),
+    CONSTRAINT deal_sli_targets_latency_check CHECK (
+        latency_ms IS NULL OR latency_ms >= 0
+    )
+);
+
+CREATE TABLE deal_sli_pieces (
+    deal_id TEXT NOT NULL REFERENCES deal_sli_targets(deal_id) ON DELETE CASCADE,
+    piece_index INTEGER NOT NULL,
+    piece_cid TEXT NOT NULL,
+    piece_size_bytes NUMERIC(78, 0),
+    allocation_id TEXT,
+    claim_id TEXT,
+    PRIMARY KEY (deal_id, piece_index),
+    CONSTRAINT deal_sli_pieces_index_check CHECK (piece_index >= 0),
+    CONSTRAINT deal_sli_pieces_size_check CHECK (
+        piece_size_bytes IS NULL OR piece_size_bytes >= 0
+    )
+);
+
+CREATE TABLE deal_sli_runs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    deal_id TEXT NOT NULL REFERENCES deal_sli_targets(deal_id) ON DELETE CASCADE,
+    state TEXT NOT NULL,
+    measurement_state TEXT NOT NULL,
+    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    tested_at TIMESTAMPTZ,
+    provider_id TEXT NOT NULL,
+    client_id TEXT,
+    working_url TEXT,
+    retrievability_percent NUMERIC(5, 2),
+    large_files_percent NUMERIC(5, 2),
+    car_files_percent NUMERIC(5, 2),
+    sector_utilization_percent NUMERIC(5, 2),
+    is_consistent BOOLEAN,
+    is_reliable BOOLEAN,
+    result_code result_code,
+    error_code error_code,
+    piece_count INTEGER NOT NULL,
+    success_count INTEGER NOT NULL,
+    failed_count INTEGER NOT NULL,
+    url_metadata JSONB,
+    CONSTRAINT deal_sli_runs_state_check CHECK (state IN ('running', 'completed')),
+    CONSTRAINT deal_sli_runs_measurement_state_check CHECK (
+        measurement_state IN ('missing', 'fresh', 'stale', 'failed', 'skipped')
+    ),
+    CONSTRAINT deal_sli_runs_retri_check CHECK (
+        retrievability_percent IS NULL
+        OR (retrievability_percent >= 0.0 AND retrievability_percent <= 100.0)
+    ),
+    CONSTRAINT deal_sli_runs_large_check CHECK (
+        large_files_percent IS NULL
+        OR (large_files_percent >= 0.0 AND large_files_percent <= 100.0)
+    ),
+    CONSTRAINT deal_sli_runs_car_check CHECK (
+        car_files_percent IS NULL
+        OR (car_files_percent >= 0.0 AND car_files_percent <= 100.0)
+    ),
+    CONSTRAINT deal_sli_runs_sector_check CHECK (
+        sector_utilization_percent IS NULL OR sector_utilization_percent >= 0.0
+    ),
+    CONSTRAINT deal_sli_runs_counts_check CHECK (
+        piece_count >= 0
+        AND success_count >= 0
+        AND failed_count >= 0
+        AND success_count + failed_count <= piece_count
+    ),
+    CONSTRAINT deal_sli_runs_id_deal_unique UNIQUE (id, deal_id)
+);
+
+CREATE TABLE deal_sli_piece_results (
+    run_id UUID NOT NULL,
+    deal_id TEXT NOT NULL,
+    piece_index INTEGER NOT NULL,
+    piece_cid TEXT NOT NULL,
+    url_tested TEXT NOT NULL,
+    success BOOLEAN NOT NULL,
+    content_length BIGINT,
+    is_valid_car BOOLEAN,
+    result_code result_code,
+    tested_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (run_id, piece_index, url_tested),
+    FOREIGN KEY (run_id, deal_id)
+        REFERENCES deal_sli_runs(id, deal_id) ON DELETE CASCADE,
+    FOREIGN KEY (deal_id, piece_index)
+        REFERENCES deal_sli_pieces(deal_id, piece_index),
+    CONSTRAINT deal_sli_piece_results_content_length_check CHECK (
+        content_length IS NULL OR content_length >= 0
+    )
+);
+
+CREATE INDEX idx_deal_sli_runs_deal_started
+    ON deal_sli_runs (deal_id, started_at DESC);
+
+CREATE INDEX idx_deal_sli_runs_latest_completed
+    ON deal_sli_runs (deal_id, completed_at DESC)
+    WHERE state = 'completed';
+
+CREATE INDEX idx_deal_sli_targets_provider
+    ON deal_sli_targets (provider_id, updated_at DESC);
+
+CREATE INDEX idx_deal_sli_piece_results_run
+    ON deal_sli_piece_results (run_id);
+
+CREATE INDEX idx_deal_sli_piece_results_deal
+    ON deal_sli_piece_results (deal_id, piece_index);

--- a/scripts/setup_dev_db.sh
+++ b/scripts/setup_dev_db.sh
@@ -15,10 +15,18 @@ if [ -z "$DATABASE_URL" ]; then
     exit 1
 fi
 
+run_psql() {
+    if command -v psql > /dev/null 2>&1; then
+        psql "$DATABASE_URL" "$@"
+    else
+        docker compose exec -T postgres psql -U postgres -d uf "$@"
+    fi
+}
+
 echo "Setting up development database..."
 
 # Create unified_verified_deal table (matches DMOB schema)
-psql "$DATABASE_URL" <<EOF
+run_psql <<EOF
 -- Drop if exists (for clean resets)
 DROP TABLE IF EXISTS unified_verified_deal CASCADE;
 
@@ -59,7 +67,7 @@ EOF
 echo "Table created. Seeding sample data..."
 
 # Seed with sample data
-psql "$DATABASE_URL" < scripts/sql/$FILE_NAME
+run_psql < scripts/sql/$FILE_NAME
 
 echo "✓ Development database setup complete!"
 echo "✓ unified_verified_deal table created and seeded"

--- a/url_finder/src/api/api_doc.rs
+++ b/url_finder/src/api/api_doc.rs
@@ -66,10 +66,11 @@ The `/url/*` endpoints remain fully backward compatible.
         handle_reset_provider,
         handle_history_retrievability,
         handle_history_retrievability_client,
-        // Deal measurement shell API
+        // Deal SLI API
         handle_upsert_deal,
         handle_get_deal,
         handle_get_latest,
+        handle_create_run,
     ),
     components(
         schemas(
@@ -115,7 +116,7 @@ The `/url/*` endpoints remain fully backward compatible.
             DiagnosticsResponse,
             ScheduleStateResponse,
             SchedulingResponse,
-            // Deal measurement shell API
+            // Deal SLI API
             DealPath,
             DealVersion,
             MeasurementState,

--- a/url_finder/src/api/deals/create_run.rs
+++ b/url_finder/src/api/deals/create_run.rs
@@ -6,35 +6,39 @@ use axum::{
 };
 use axum_extra::extract::WithRejection;
 
-use super::{DealPath, DealTargetResponse};
+use super::{DealLatestMeasurementResponse, DealPath};
 use crate::{
     AppState,
     api_response::{
         ApiResponse, ErrorCode, ErrorResponse, bad_request_with_code,
         internal_server_error_with_code, not_found_with_code, ok_response,
     },
+    auth::OracleAuth,
     services::deal_sli_service::DealSliServiceError,
 };
 
 #[utoipa::path(
-    get,
-    path = "/deals/{deal_id}",
-    description = "Return a persisted Deal SLI target and its measurable pieces.",
+    post,
+    path = "/deals/{deal_id}/runs",
+    description = "Persist a manual synchronous Deal SLI run result and return the stored latest run data.",
     params(DealPath),
     responses(
-        (status = 200, description = "Stored deal target", body = DealTargetResponse),
+        (status = 200, description = "Stored latest deal run", body = DealLatestMeasurementResponse),
         (status = 400, description = "Invalid path", body = ErrorResponse),
+        (status = 401, description = "Missing or invalid oracle bearer token", body = ErrorResponse),
         (status = 404, description = "Deal target not found", body = ErrorResponse),
         (status = 500, description = "Internal error", body = ErrorResponse),
     ),
+    security(("bearer_auth" = [])),
     tags = ["Deals"],
 )]
 #[debug_handler(state = Arc<AppState>)]
-pub async fn handle_get_deal(
+pub async fn handle_create_run(
+    _auth: OracleAuth,
     State(state): State<Arc<AppState>>,
     WithRejection(Path(path), _): WithRejection<Path<DealPath>, ApiResponse<ErrorResponse>>,
-) -> Result<ApiResponse<DealTargetResponse>, ApiResponse<()>> {
-    let response = state.deal_sli_service.get_target(&path.deal_id).await;
+) -> Result<ApiResponse<DealLatestMeasurementResponse>, ApiResponse<()>> {
+    let response = state.deal_sli_service.create_run(&path.deal_id).await;
     match response {
         Ok(data) => Ok(ok_response(data)),
         Err(DealSliServiceError::InvalidRequest(message)) => {

--- a/url_finder/src/api/deals/get_latest.rs
+++ b/url_finder/src/api/deals/get_latest.rs
@@ -1,25 +1,51 @@
-use axum::{debug_handler, extract::Path};
+use std::sync::Arc;
+
+use axum::{
+    debug_handler,
+    extract::{Path, State},
+};
 use axum_extra::extract::WithRejection;
 
 use super::{DealLatestMeasurementResponse, DealPath};
-use crate::api_response::{ApiResponse, ErrorResponse, ok_response};
+use crate::{
+    AppState,
+    api_response::{
+        ApiResponse, ErrorCode, ErrorResponse, bad_request_with_code,
+        internal_server_error_with_code, not_found_with_code, ok_response,
+    },
+    services::deal_sli_service::DealSliServiceError,
+};
 
 #[utoipa::path(
     get,
     path = "/deals/{deal_id}/latest",
-    description = "Contract shell for oracle-service integration. This route returns the documented response shape, but deal target persistence and measurement execution are not implemented in this slice.",
+    description = "Return the latest stored Deal SLI measurement state for a persisted target.",
     params(DealPath),
     responses(
-        (status = 200, description = "Latest deal measurement shell response", body = DealLatestMeasurementResponse),
+        (status = 200, description = "Latest stored deal measurement", body = DealLatestMeasurementResponse),
         (status = 400, description = "Invalid path", body = ErrorResponse),
+        (status = 404, description = "Deal target not found", body = ErrorResponse),
+        (status = 500, description = "Internal error", body = ErrorResponse),
     ),
     tags = ["Deals"],
 )]
-#[debug_handler]
+#[debug_handler(state = Arc<AppState>)]
 pub async fn handle_get_latest(
+    State(state): State<Arc<AppState>>,
     WithRejection(Path(path), _): WithRejection<Path<DealPath>, ApiResponse<ErrorResponse>>,
 ) -> Result<ApiResponse<DealLatestMeasurementResponse>, ApiResponse<()>> {
-    Ok(ok_response(DealLatestMeasurementResponse::missing(
-        path.deal_id,
-    )))
+    let response = state.deal_sli_service.get_latest(&path.deal_id).await;
+    match response {
+        Ok(data) => Ok(ok_response(data)),
+        Err(DealSliServiceError::InvalidRequest(message)) => {
+            Err(bad_request_with_code(ErrorCode::InvalidRequest, message))
+        }
+        Err(DealSliServiceError::NotFound(message)) => {
+            Err(not_found_with_code(ErrorCode::NotFound, message))
+        }
+        Err(DealSliServiceError::Internal(error)) => Err(internal_server_error_with_code(
+            ErrorCode::InternalError,
+            error.to_string(),
+        )),
+    }
 }

--- a/url_finder/src/api/deals/mod.rs
+++ b/url_finder/src/api/deals/mod.rs
@@ -1,8 +1,10 @@
+mod create_run;
 mod get_deal;
 mod get_latest;
 mod types;
 mod upsert_deal;
 
+pub use create_run::*;
 pub use get_deal::*;
 pub use get_latest::*;
 pub use types::*;

--- a/url_finder/src/api/deals/types.rs
+++ b/url_finder/src/api/deals/types.rs
@@ -62,8 +62,6 @@ pub struct DealTargetUpsertRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub manifest_location: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub requested_size_bytes: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub requirements: Option<DealSliRequirements>,
     #[serde(default)]
     pub pieces: Vec<DealPieceTarget>,
@@ -77,7 +75,6 @@ pub struct DealTargetResponse {
     pub client: Option<String>,
     pub manifest_hash: Option<String>,
     pub manifest_location: Option<String>,
-    pub requested_size_bytes: Option<String>,
     pub requirements: Option<DealSliRequirements>,
     #[serde(default)]
     pub pieces: Vec<DealPieceTarget>,
@@ -121,7 +118,6 @@ impl DealTargetResponse {
             client: None,
             manifest_hash: None,
             manifest_location: None,
-            requested_size_bytes: None,
             requirements: None,
             pieces: Vec::new(),
             created_at: None,
@@ -137,7 +133,6 @@ impl DealTargetResponse {
             client: request.client,
             manifest_hash: request.manifest_hash,
             manifest_location: request.manifest_location,
-            requested_size_bytes: request.requested_size_bytes,
             requirements: request.requirements,
             pieces: request.pieces,
             created_at: None,
@@ -148,6 +143,10 @@ impl DealTargetResponse {
 
 impl DealLatestMeasurementResponse {
     pub fn missing(deal_id: String) -> Self {
+        Self::missing_with_piece_count(deal_id, 0)
+    }
+
+    pub fn missing_with_piece_count(deal_id: String, piece_count: u32) -> Self {
         Self {
             deal_id,
             measurement_state: MeasurementState::Missing,
@@ -161,7 +160,7 @@ impl DealLatestMeasurementResponse {
             is_reliable: None,
             result_code: None,
             error_code: None,
-            piece_count: 0,
+            piece_count,
             success_count: 0,
             failed_count: 0,
             performance: DealPerformanceResponse::default(),
@@ -183,7 +182,6 @@ mod tests {
             client: Some("f05678".to_string()),
             manifest_hash: Some("bafy-manifest".to_string()),
             manifest_location: Some("https://example.com/manifest.car".to_string()),
-            requested_size_bytes: Some("2048".to_string()),
             requirements: Some(DealSliRequirements {
                 retrievability_bps: 9_500,
                 bandwidth_mbps: Some(200),
@@ -207,7 +205,6 @@ mod tests {
                 "client": "f05678",
                 "manifest_hash": "bafy-manifest",
                 "manifest_location": "https://example.com/manifest.car",
-                "requested_size_bytes": "2048",
                 "requirements": {
                     "retrievability_bps": 9500,
                     "bandwidth_mbps": 200,

--- a/url_finder/src/api/deals/upsert_deal.rs
+++ b/url_finder/src/api/deals/upsert_deal.rs
@@ -1,25 +1,34 @@
 use std::sync::Arc;
 
-use axum::{Json, debug_handler, extract::Path};
+use axum::{
+    Json, debug_handler,
+    extract::{Path, State},
+};
 use axum_extra::extract::WithRejection;
 
 use super::{DealPath, DealTargetResponse, DealTargetUpsertRequest};
 use crate::{
     AppState,
-    api_response::{ApiResponse, ErrorResponse, ok_response},
+    api_response::{
+        ApiResponse, ErrorCode, ErrorResponse, bad_request_with_code,
+        internal_server_error_with_code, not_found_with_code, ok_response,
+    },
     auth::OracleAuth,
+    services::deal_sli_service::DealSliServiceError,
 };
 
 #[utoipa::path(
     put,
     path = "/deals/{deal_id}",
-    description = "Contract shell for oracle-service integration. This route returns the documented response shape, but deal target persistence and measurement execution are not implemented in this slice.",
+    description = "Create or update a persisted Deal SLI target and its measurable pieces.",
     request_body = DealTargetUpsertRequest,
     params(DealPath),
     responses(
-        (status = 200, description = "Deal target shell response", body = DealTargetResponse),
+        (status = 200, description = "Stored deal target", body = DealTargetResponse),
         (status = 400, description = "Invalid path or request body", body = ErrorResponse),
         (status = 401, description = "Missing or invalid oracle bearer token", body = ErrorResponse),
+        (status = 404, description = "Deal target not found", body = ErrorResponse),
+        (status = 500, description = "Internal error", body = ErrorResponse),
     ),
     security(("bearer_auth" = [])),
     tags = ["Deals"],
@@ -27,14 +36,28 @@ use crate::{
 #[debug_handler(state = Arc<AppState>)]
 pub async fn handle_upsert_deal(
     _auth: OracleAuth,
+    State(state): State<Arc<AppState>>,
     WithRejection(Path(path), _): WithRejection<Path<DealPath>, ApiResponse<ErrorResponse>>,
     WithRejection(Json(request), _): WithRejection<
         Json<DealTargetUpsertRequest>,
         ApiResponse<ErrorResponse>,
     >,
 ) -> Result<ApiResponse<DealTargetResponse>, ApiResponse<()>> {
-    Ok(ok_response(DealTargetResponse::from_upsert_request(
-        path.deal_id,
-        request,
-    )))
+    let response = state
+        .deal_sli_service
+        .upsert_target(&path.deal_id, request)
+        .await;
+    match response {
+        Ok(data) => Ok(ok_response(data)),
+        Err(DealSliServiceError::InvalidRequest(message)) => {
+            Err(bad_request_with_code(ErrorCode::InvalidRequest, message))
+        }
+        Err(DealSliServiceError::NotFound(message)) => {
+            Err(not_found_with_code(ErrorCode::NotFound, message))
+        }
+        Err(DealSliServiceError::Internal(error)) => Err(internal_server_error_with_code(
+            ErrorCode::InternalError,
+            error.to_string(),
+        )),
+    }
 }

--- a/url_finder/src/lib.rs
+++ b/url_finder/src/lib.rs
@@ -27,9 +27,11 @@ pub use types::{ErrorCode, ResultCode};
 
 pub struct AppState {
     pub deal_repo: Arc<repository::DealRepository>,
+    pub deal_sli_repo: Arc<repository::DealSliRepository>,
     pub storage_provider_repo: Arc<repository::StorageProviderRepository>,
     pub url_repo: Arc<repository::UrlResultRepository>,
     pub bms_repo: Arc<repository::BmsBandwidthResultRepository>,
+    pub deal_sli_service: Arc<services::deal_sli_service::DealSliService>,
     pub provider_service: Arc<services::provider_service::ProviderService>,
     pub config: Arc<config::Config>,
 }

--- a/url_finder/src/main.rs
+++ b/url_finder/src/main.rs
@@ -45,6 +45,7 @@ async fn main() -> Result<()> {
 
     let sp_repo = Arc::new(StorageProviderRepository::new(pool.clone()));
     let deal_repo = Arc::new(DealRepository::new(dmob_pool.clone()));
+    let deal_sli_repo = Arc::new(DealSliRepository::new(pool.clone()));
     let url_repo = Arc::new(UrlResultRepository::new(pool.clone()));
     let bms_result_repo = Arc::new(BmsBandwidthResultRepository::new(pool.clone()));
     let bms_client = Arc::new(url_finder::bms_client::BmsClient::new(
@@ -58,12 +59,19 @@ async fn main() -> Result<()> {
             sp_repo.clone(),
         ),
     );
+    let deal_sli_service = Arc::new(url_finder::services::deal_sli_service::DealSliService::new(
+        deal_sli_repo.clone(),
+        sp_repo.clone(),
+        config.clone(),
+    ));
 
     let app_state = Arc::new(AppState {
         deal_repo: deal_repo.clone(),
+        deal_sli_repo: deal_sli_repo.clone(),
         storage_provider_repo: sp_repo.clone(),
         url_repo: url_repo.clone(),
         bms_repo: bms_result_repo.clone(),
+        deal_sli_service,
         provider_service,
         config: config.clone(),
     });

--- a/url_finder/src/repository/deal_sli_repo.rs
+++ b/url_finder/src/repository/deal_sli_repo.rs
@@ -390,7 +390,8 @@ impl DealSliRepository {
                     AND state = 'completed'
                ORDER BY
                     completed_at DESC NULLS LAST,
-                    started_at DESC
+                    started_at DESC,
+                    id DESC
                LIMIT
                     1
             "#,

--- a/url_finder/src/repository/deal_sli_repo.rs
+++ b/url_finder/src/repository/deal_sli_repo.rs
@@ -1,0 +1,626 @@
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use color_eyre::{Result, eyre::eyre};
+use sqlx::PgPool;
+use sqlx::types::BigDecimal;
+use uuid::Uuid;
+
+use crate::{ErrorCode, ResultCode};
+
+#[derive(Clone)]
+pub struct DealSliRepository {
+    pool: PgPool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DealSliRequirementValues {
+    pub retrievability_bps: Option<i32>,
+    pub bandwidth_mbps: Option<i32>,
+    pub latency_ms: Option<i32>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewDealSliTarget {
+    pub deal_id: String,
+    pub deal_version: String,
+    pub provider_id: String,
+    pub client_id: Option<String>,
+    pub manifest_hash: Option<String>,
+    pub manifest_location: Option<String>,
+    pub requirements: DealSliRequirementValues,
+    pub pieces: Vec<NewDealSliPiece>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewDealSliPiece {
+    pub piece_index: i32,
+    pub piece_cid: String,
+    pub piece_size_bytes: Option<BigDecimal>,
+    pub allocation_id: Option<String>,
+    pub claim_id: Option<String>,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct DealSliTarget {
+    pub deal_id: String,
+    pub deal_version: String,
+    pub provider_id: String,
+    pub client_id: Option<String>,
+    pub manifest_hash: Option<String>,
+    pub manifest_location: Option<String>,
+    pub retrievability_bps: Option<i32>,
+    pub bandwidth_mbps: Option<i32>,
+    pub latency_ms: Option<i32>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct DealSliPiece {
+    pub deal_id: String,
+    pub piece_index: i32,
+    pub piece_cid: String,
+    pub piece_size_bytes: Option<BigDecimal>,
+    pub allocation_id: Option<String>,
+    pub claim_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DealSliTargetWithPieces {
+    pub target: DealSliTarget,
+    pub pieces: Vec<DealSliPiece>,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct DealSliLatestRun {
+    pub deal_id: String,
+    pub measurement_state: String,
+    pub tested_at: Option<DateTime<Utc>>,
+    pub working_url: Option<String>,
+    pub retrievability_percent: Option<BigDecimal>,
+    pub large_files_percent: Option<BigDecimal>,
+    pub car_files_percent: Option<BigDecimal>,
+    pub sector_utilization_percent: Option<BigDecimal>,
+    pub is_consistent: Option<bool>,
+    pub is_reliable: Option<bool>,
+    pub result_code: Option<ResultCode>,
+    pub error_code: Option<ErrorCode>,
+    pub piece_count: i32,
+    pub success_count: i32,
+    pub failed_count: i32,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewDealSliPieceResult {
+    pub deal_id: String,
+    pub piece_index: i32,
+    pub piece_cid: String,
+    pub url_tested: String,
+    pub success: bool,
+    pub content_length: Option<i64>,
+    pub is_valid_car: bool,
+    pub result_code: ResultCode,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewCompletedDealSliRun {
+    pub deal_id: String,
+    pub target_pieces: Vec<DealSliRunPieceSnapshot>,
+    pub measurement_state: String,
+    pub provider_id: String,
+    pub client_id: Option<String>,
+    pub working_url: Option<String>,
+    pub retrievability_percent: Option<BigDecimal>,
+    pub large_files_percent: Option<BigDecimal>,
+    pub car_files_percent: Option<BigDecimal>,
+    pub sector_utilization_percent: Option<BigDecimal>,
+    pub is_consistent: Option<bool>,
+    pub is_reliable: Option<bool>,
+    pub result_code: ResultCode,
+    pub piece_count: i32,
+    pub success_count: i32,
+    pub failed_count: i32,
+    pub piece_results: Vec<NewDealSliPieceResult>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DealSliRunPieceSnapshot {
+    pub piece_index: i32,
+    pub piece_cid: String,
+    pub piece_size_bytes: Option<BigDecimal>,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct InsertedDealSliRun {
+    id: Uuid,
+    deal_id: String,
+    measurement_state: String,
+    tested_at: Option<DateTime<Utc>>,
+    working_url: Option<String>,
+    retrievability_percent: Option<BigDecimal>,
+    large_files_percent: Option<BigDecimal>,
+    car_files_percent: Option<BigDecimal>,
+    sector_utilization_percent: Option<BigDecimal>,
+    is_consistent: Option<bool>,
+    is_reliable: Option<bool>,
+    result_code: Option<ResultCode>,
+    error_code: Option<ErrorCode>,
+    piece_count: i32,
+    success_count: i32,
+    failed_count: i32,
+}
+
+impl DealSliRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn upsert_target(&self, target: &NewDealSliTarget) -> Result<()> {
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query_scalar!(
+            r#"SELECT
+                    deal_id
+               FROM
+                    deal_sli_targets
+               WHERE
+                    deal_id = $1
+               FOR UPDATE
+            "#,
+            &target.deal_id
+        )
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let existing_pieces = sqlx::query_as!(
+            DealSliPiece,
+            r#"SELECT
+                    deal_id,
+                    piece_index,
+                    piece_cid,
+                    piece_size_bytes,
+                    allocation_id,
+                    claim_id
+               FROM
+                    deal_sli_pieces
+               WHERE
+                    deal_id = $1
+               ORDER BY
+                    piece_index ASC
+            "#,
+            &target.deal_id
+        )
+        .fetch_all(&mut *tx)
+        .await?;
+
+        let has_runs = sqlx::query_scalar!(
+            r#"SELECT
+                    EXISTS (
+                        SELECT
+                            1
+                        FROM
+                            deal_sli_runs
+                        WHERE
+                            deal_id = $1
+                    ) AS "exists!"
+            "#,
+            &target.deal_id
+        )
+        .fetch_one(&mut *tx)
+        .await?;
+
+        if has_runs {
+            validate_measured_pieces_are_unchanged(&target.pieces, &existing_pieces)?;
+        }
+
+        sqlx::query!(
+            r#"INSERT INTO
+                    deal_sli_targets (
+                        deal_id,
+                        deal_version,
+                        provider_id,
+                        client_id,
+                        manifest_hash,
+                        manifest_location,
+                        retrievability_bps,
+                        bandwidth_mbps,
+                        latency_ms
+                    )
+               VALUES
+                    ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+               ON CONFLICT (deal_id) DO UPDATE SET
+                    deal_version = EXCLUDED.deal_version,
+                    provider_id = EXCLUDED.provider_id,
+                    client_id = EXCLUDED.client_id,
+                    manifest_hash = EXCLUDED.manifest_hash,
+                    manifest_location = EXCLUDED.manifest_location,
+                    retrievability_bps = EXCLUDED.retrievability_bps,
+                    bandwidth_mbps = EXCLUDED.bandwidth_mbps,
+                    latency_ms = EXCLUDED.latency_ms,
+                    updated_at = NOW()
+            "#,
+            &target.deal_id,
+            &target.deal_version,
+            &target.provider_id,
+            target.client_id.as_deref(),
+            target.manifest_hash.as_deref(),
+            target.manifest_location.as_deref(),
+            target.requirements.retrievability_bps,
+            target.requirements.bandwidth_mbps,
+            target.requirements.latency_ms
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        if !has_runs {
+            let piece_indexes = target
+                .pieces
+                .iter()
+                .map(|piece| piece.piece_index)
+                .collect::<Vec<_>>();
+
+            sqlx::query!(
+                r#"DELETE FROM
+                        deal_sli_pieces
+                   WHERE
+                        deal_id = $1
+                        AND NOT (piece_index = ANY($2::int4[]))
+                "#,
+                &target.deal_id,
+                &piece_indexes
+            )
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        for piece in &target.pieces {
+            sqlx::query!(
+                r#"INSERT INTO
+                        deal_sli_pieces (
+                            deal_id,
+                            piece_index,
+                            piece_cid,
+                            piece_size_bytes,
+                            allocation_id,
+                            claim_id
+                        )
+                   VALUES
+                        ($1, $2, $3, $4, $5, $6)
+                   ON CONFLICT (deal_id, piece_index) DO UPDATE SET
+                        piece_cid = EXCLUDED.piece_cid,
+                        piece_size_bytes = EXCLUDED.piece_size_bytes,
+                        allocation_id = EXCLUDED.allocation_id,
+                        claim_id = EXCLUDED.claim_id
+                "#,
+                &target.deal_id,
+                piece.piece_index,
+                &piece.piece_cid,
+                piece.piece_size_bytes.as_ref(),
+                piece.allocation_id.as_deref(),
+                piece.claim_id.as_deref()
+            )
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    pub async fn get_target(&self, deal_id: &str) -> Result<Option<DealSliTargetWithPieces>> {
+        let target = sqlx::query_as!(
+            DealSliTarget,
+            r#"SELECT
+                    deal_id,
+                    deal_version,
+                    provider_id,
+                    client_id,
+                    manifest_hash,
+                    manifest_location,
+                    retrievability_bps,
+                    bandwidth_mbps,
+                    latency_ms,
+                    created_at,
+                    updated_at
+               FROM
+                    deal_sli_targets
+               WHERE
+                    deal_id = $1
+            "#,
+            deal_id
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+
+        let Some(target) = target else {
+            return Ok(None);
+        };
+
+        let pieces = sqlx::query_as!(
+            DealSliPiece,
+            r#"SELECT
+                    deal_id,
+                    piece_index,
+                    piece_cid,
+                    piece_size_bytes,
+                    allocation_id,
+                    claim_id
+               FROM
+                    deal_sli_pieces
+               WHERE
+                    deal_id = $1
+               ORDER BY
+                    piece_index ASC
+            "#,
+            deal_id
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(Some(DealSliTargetWithPieces { target, pieces }))
+    }
+
+    pub async fn get_latest_completed_run(
+        &self,
+        deal_id: &str,
+    ) -> Result<Option<DealSliLatestRun>> {
+        Ok(sqlx::query_as!(
+            DealSliLatestRun,
+            r#"SELECT
+                    deal_id,
+                    measurement_state,
+                    tested_at,
+                    working_url,
+                    retrievability_percent,
+                    large_files_percent,
+                    car_files_percent,
+                    sector_utilization_percent,
+                    is_consistent,
+                    is_reliable,
+                    result_code AS "result_code: ResultCode",
+                    error_code AS "error_code: ErrorCode",
+                    piece_count,
+                    success_count,
+                    failed_count
+               FROM
+                    deal_sli_runs
+               WHERE
+                    deal_id = $1
+                    AND state = 'completed'
+               ORDER BY
+                    completed_at DESC NULLS LAST,
+                    started_at DESC
+               LIMIT
+                    1
+            "#,
+            deal_id
+        )
+        .fetch_optional(&self.pool)
+        .await?)
+    }
+
+    pub async fn insert_completed_run_with_piece_results(
+        &self,
+        run: &NewCompletedDealSliRun,
+    ) -> Result<DealSliLatestRun> {
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query_scalar!(
+            r#"SELECT
+                    deal_id
+               FROM
+                    deal_sli_targets
+               WHERE
+                    deal_id = $1
+               FOR UPDATE
+            "#,
+            &run.deal_id
+        )
+        .fetch_one(&mut *tx)
+        .await?;
+
+        let current_pieces = sqlx::query_as!(
+            DealSliPiece,
+            r#"SELECT
+                    deal_id,
+                    piece_index,
+                    piece_cid,
+                    piece_size_bytes,
+                    allocation_id,
+                    claim_id
+               FROM
+                    deal_sli_pieces
+               WHERE
+                    deal_id = $1
+               ORDER BY
+                    piece_index ASC
+            "#,
+            &run.deal_id
+        )
+        .fetch_all(&mut *tx)
+        .await?;
+        validate_run_target_pieces_are_current(&run.target_pieces, &current_pieces)?;
+
+        let inserted = sqlx::query_as!(
+            InsertedDealSliRun,
+            r#"INSERT INTO
+                    deal_sli_runs (
+                        deal_id,
+                        state,
+                        measurement_state,
+                        completed_at,
+                        tested_at,
+                        provider_id,
+                        client_id,
+                        working_url,
+                        retrievability_percent,
+                        large_files_percent,
+                        car_files_percent,
+                        sector_utilization_percent,
+                        is_consistent,
+                        is_reliable,
+                        result_code,
+                        piece_count,
+                        success_count,
+                        failed_count
+                    )
+               VALUES
+                    ($1, 'completed', $2, NOW(), NOW(), $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+               RETURNING
+                    id,
+                    deal_id,
+                    measurement_state,
+                    tested_at,
+                    working_url,
+                    retrievability_percent,
+                    large_files_percent,
+                    car_files_percent,
+                    sector_utilization_percent,
+                    is_consistent,
+                    is_reliable,
+                    result_code AS "result_code: ResultCode",
+                    error_code AS "error_code: ErrorCode",
+                    piece_count,
+                    success_count,
+                    failed_count
+            "#,
+            run.deal_id,
+            run.measurement_state,
+            run.provider_id,
+            run.client_id.as_deref(),
+            run.working_url.as_deref(),
+            run.retrievability_percent.as_ref(),
+            run.large_files_percent.as_ref(),
+            run.car_files_percent.as_ref(),
+            run.sector_utilization_percent.as_ref(),
+            run.is_consistent,
+            run.is_reliable,
+            run.result_code.clone() as ResultCode,
+            run.piece_count,
+            run.success_count,
+            run.failed_count,
+        )
+        .fetch_one(&mut *tx)
+        .await?;
+
+        for piece_result in &run.piece_results {
+            sqlx::query!(
+                r#"INSERT INTO
+                        deal_sli_piece_results (
+                            run_id,
+                            deal_id,
+                            piece_index,
+                            piece_cid,
+                            url_tested,
+                            success,
+                            content_length,
+                            is_valid_car,
+                            result_code,
+                            tested_at
+                        )
+                   VALUES
+                        ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+                "#,
+                inserted.id,
+                piece_result.deal_id,
+                piece_result.piece_index,
+                piece_result.piece_cid,
+                piece_result.url_tested,
+                piece_result.success,
+                piece_result.content_length,
+                piece_result.is_valid_car,
+                piece_result.result_code.clone() as ResultCode,
+            )
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+
+        Ok(DealSliLatestRun {
+            deal_id: inserted.deal_id,
+            measurement_state: inserted.measurement_state,
+            tested_at: inserted.tested_at,
+            working_url: inserted.working_url,
+            retrievability_percent: inserted.retrievability_percent,
+            large_files_percent: inserted.large_files_percent,
+            car_files_percent: inserted.car_files_percent,
+            sector_utilization_percent: inserted.sector_utilization_percent,
+            is_consistent: inserted.is_consistent,
+            is_reliable: inserted.is_reliable,
+            result_code: inserted.result_code,
+            error_code: inserted.error_code,
+            piece_count: inserted.piece_count,
+            success_count: inserted.success_count,
+            failed_count: inserted.failed_count,
+        })
+    }
+}
+
+fn validate_measured_pieces_are_unchanged(
+    requested_pieces: &[NewDealSliPiece],
+    existing_pieces: &[DealSliPiece],
+) -> Result<()> {
+    let requested_by_index = requested_pieces
+        .iter()
+        .map(|piece| (piece.piece_index, piece))
+        .collect::<BTreeMap<_, _>>();
+
+    if requested_by_index.len() != requested_pieces.len() {
+        return Err(eyre!(
+            "deal SLI pieces contain duplicate piece_index values"
+        ));
+    }
+
+    if requested_by_index.len() != existing_pieces.len() {
+        return Err(eyre!(
+            "deal SLI pieces cannot be added or removed after measurement results exist"
+        ));
+    }
+
+    for existing in existing_pieces {
+        let Some(requested) = requested_by_index.get(&existing.piece_index) else {
+            return Err(eyre!(
+                "deal SLI piece {} cannot be removed after measurement results exist",
+                existing.piece_index
+            ));
+        };
+
+        if existing.piece_cid != requested.piece_cid
+            || existing.piece_size_bytes != requested.piece_size_bytes
+        {
+            return Err(eyre!(
+                "deal SLI piece {} cid or size cannot change after measurement results exist",
+                existing.piece_index
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_run_target_pieces_are_current(
+    expected_pieces: &[DealSliRunPieceSnapshot],
+    current_pieces: &[DealSliPiece],
+) -> Result<()> {
+    if expected_pieces.len() != current_pieces.len() {
+        return Err(eyre!(
+            "deal SLI run target pieces changed before run insertion"
+        ));
+    }
+
+    for (expected, current) in expected_pieces.iter().zip(current_pieces) {
+        if expected.piece_index != current.piece_index
+            || expected.piece_cid != current.piece_cid
+            || expected.piece_size_bytes != current.piece_size_bytes
+        {
+            return Err(eyre!(
+                "deal SLI run target piece {} changed before run insertion",
+                expected.piece_index
+            ));
+        }
+    }
+
+    Ok(())
+}

--- a/url_finder/src/repository/mod.rs
+++ b/url_finder/src/repository/mod.rs
@@ -1,9 +1,11 @@
 mod bms_result_repo;
 mod deal_repo;
+mod deal_sli_repo;
 mod storage_provider_repo;
 mod url_result_repo;
 
 pub use bms_result_repo::*;
 pub use deal_repo::*;
+pub use deal_sli_repo::*;
 pub use storage_provider_repo::*;
 pub use url_result_repo::*;

--- a/url_finder/src/routes.rs
+++ b/url_finder/src/routes.rs
@@ -110,6 +110,7 @@ pub fn create_routes() -> Router<Arc<AppState>> {
         .route("/deals/{deal_id}", put(deals::handle_upsert_deal))
         .route("/deals/{deal_id}", get(deals::handle_get_deal))
         .route("/deals/{deal_id}/latest", get(deals::handle_get_latest))
+        .route("/deals/{deal_id}/runs", post(deals::handle_create_run))
         .layer(
             GovernorLayer::new(governor_config.clone())
                 .error_handler(too_many_requests_error_handler),

--- a/url_finder/src/services/deal_sli_service.rs
+++ b/url_finder/src/services/deal_sli_service.rs
@@ -19,7 +19,7 @@ use crate::{
     url_tester::test_urls_double_tap,
 };
 
-const MAX_MANUAL_RUN_URL_TESTS: usize = 512;
+const MAX_MANUAL_RUN_URL_TESTS: usize = 2_048;
 
 #[derive(Debug)]
 pub enum DealSliServiceError {
@@ -206,11 +206,6 @@ impl DealSliService {
         let piece_count = stored.pieces.len() as i32;
         let success_count = successful_piece_indexes.len() as i32;
         let failed_count = piece_count - success_count;
-        let result_code = if success_count == piece_count {
-            ResultCode::Success
-        } else {
-            ResultCode::FailedToGetWorkingUrl
-        };
         let piece_results = test_contexts
             .iter()
             .zip(url_results.iter())
@@ -221,6 +216,11 @@ impl DealSliService {
             .filter(|result| result.success)
             .max_by_key(|result| result.content_length)
             .map(|result| result.url.clone());
+        let result_code = if working_url.is_some() {
+            ResultCode::Success
+        } else {
+            ResultCode::FailedToGetWorkingUrl
+        };
 
         self.repo
             .insert_completed_run_with_piece_results(&NewCompletedDealSliRun {

--- a/url_finder/src/services/deal_sli_service.rs
+++ b/url_finder/src/services/deal_sli_service.rs
@@ -1,0 +1,532 @@
+use std::{collections::BTreeSet, str::FromStr, sync::Arc};
+
+use sqlx::types::BigDecimal;
+
+use crate::{
+    api::deals::{
+        DealLatestMeasurementResponse, DealPerformanceResponse, DealPieceTarget,
+        DealSliRequirements, DealTargetResponse, DealTargetUpsertRequest, DealVersion,
+        MeasurementState,
+    },
+    config::{Config, MIN_VALID_CONTENT_LENGTH},
+    http_client::build_client,
+    repository::{
+        DealSliLatestRun, DealSliPiece, DealSliRepository, DealSliRequirementValues,
+        DealSliRunPieceSnapshot, DealSliTargetWithPieces, NewCompletedDealSliRun, NewDealSliPiece,
+        NewDealSliPieceResult, NewDealSliTarget, StorageProviderRepository,
+    },
+    types::{ErrorCode, ProviderId, ResultCode, UrlTestResult},
+    url_tester::test_urls_double_tap,
+};
+
+const MAX_MANUAL_RUN_URL_TESTS: usize = 512;
+
+#[derive(Debug)]
+pub enum DealSliServiceError {
+    InvalidRequest(String),
+    NotFound(String),
+    Internal(color_eyre::Report),
+}
+
+impl From<color_eyre::Report> for DealSliServiceError {
+    fn from(error: color_eyre::Report) -> Self {
+        Self::Internal(error)
+    }
+}
+
+#[derive(Clone)]
+pub struct DealSliService {
+    repo: Arc<DealSliRepository>,
+    storage_provider_repo: Arc<StorageProviderRepository>,
+    config: Arc<Config>,
+}
+
+impl DealSliService {
+    pub fn new(
+        repo: Arc<DealSliRepository>,
+        storage_provider_repo: Arc<StorageProviderRepository>,
+        config: Arc<Config>,
+    ) -> Self {
+        Self {
+            repo,
+            storage_provider_repo,
+            config,
+        }
+    }
+
+    pub async fn upsert_target(
+        &self,
+        deal_id: &str,
+        request: DealTargetUpsertRequest,
+    ) -> std::result::Result<DealTargetResponse, DealSliServiceError> {
+        validate_deal_id(deal_id)?;
+        let target = map_upsert_request(deal_id, request)?;
+
+        self.repo
+            .upsert_target(&target)
+            .await
+            .map_err(map_target_write_error)?;
+
+        let stored = self.repo.get_target(deal_id).await?.ok_or_else(|| {
+            DealSliServiceError::NotFound(format!("Deal target {deal_id} not found"))
+        })?;
+
+        Ok(map_target_response(stored))
+    }
+
+    pub async fn get_target(
+        &self,
+        deal_id: &str,
+    ) -> std::result::Result<DealTargetResponse, DealSliServiceError> {
+        validate_deal_id(deal_id)?;
+
+        let stored = self.repo.get_target(deal_id).await?.ok_or_else(|| {
+            DealSliServiceError::NotFound(format!("Deal target {deal_id} not found"))
+        })?;
+
+        Ok(map_target_response(stored))
+    }
+
+    pub async fn get_latest(
+        &self,
+        deal_id: &str,
+    ) -> std::result::Result<DealLatestMeasurementResponse, DealSliServiceError> {
+        validate_deal_id(deal_id)?;
+
+        let stored = self.repo.get_target(deal_id).await?.ok_or_else(|| {
+            DealSliServiceError::NotFound(format!("Deal target {deal_id} not found"))
+        })?;
+
+        let latest = self.repo.get_latest_completed_run(deal_id).await?;
+        Ok(match latest {
+            Some(run) => map_latest_response(run),
+            None => DealLatestMeasurementResponse::missing_with_piece_count(
+                deal_id.to_string(),
+                stored.pieces.len() as u32,
+            ),
+        })
+    }
+
+    pub async fn create_run(
+        &self,
+        deal_id: &str,
+    ) -> std::result::Result<DealLatestMeasurementResponse, DealSliServiceError> {
+        validate_deal_id(deal_id)?;
+
+        let stored = self.repo.get_target(deal_id).await?.ok_or_else(|| {
+            DealSliServiceError::NotFound(format!("Deal target {deal_id} not found"))
+        })?;
+
+        let provider_id = ProviderId::new(stored.target.provider_id.clone()).map_err(|error| {
+            DealSliServiceError::InvalidRequest(format!("Invalid provider_id: {error}"))
+        })?;
+
+        let cached_endpoints = self
+            .storage_provider_repo
+            .get_by_provider_id(&provider_id)
+            .await?
+            .and_then(|provider| provider.cached_http_endpoints)
+            .filter(|endpoints| !endpoints.is_empty());
+
+        let latest = match cached_endpoints {
+            Some(endpoints) => {
+                self.run_cached_endpoint_measurement(deal_id, &stored, endpoints)
+                    .await?
+            }
+            None => self
+                .repo
+                .insert_completed_run_with_piece_results(&NewCompletedDealSliRun {
+                    deal_id: deal_id.to_string(),
+                    target_pieces: target_piece_snapshots(&stored.pieces),
+                    measurement_state: MeasurementState::Failed.as_str().to_string(),
+                    provider_id: stored.target.provider_id.clone(),
+                    client_id: stored.target.client_id.clone(),
+                    working_url: None,
+                    retrievability_percent: None,
+                    large_files_percent: None,
+                    car_files_percent: None,
+                    sector_utilization_percent: None,
+                    is_consistent: None,
+                    is_reliable: None,
+                    result_code: ResultCode::MissingHttpAddrFromCidContact,
+                    piece_count: stored.pieces.len() as i32,
+                    success_count: 0,
+                    failed_count: stored.pieces.len() as i32,
+                    piece_results: Vec::new(),
+                })
+                .await
+                .map_err(map_run_insert_error)?,
+        };
+
+        Ok(map_latest_response(latest))
+    }
+
+    async fn run_cached_endpoint_measurement(
+        &self,
+        deal_id: &str,
+        stored: &DealSliTargetWithPieces,
+        endpoints: Vec<String>,
+    ) -> std::result::Result<DealSliLatestRun, DealSliServiceError> {
+        let client = build_client(&self.config)
+            .map_err(|error| DealSliServiceError::Internal(color_eyre::Report::from(error)))?;
+        let test_contexts = build_piece_test_contexts(&endpoints, &stored.pieces);
+        if test_contexts.len() > MAX_MANUAL_RUN_URL_TESTS {
+            return Err(DealSliServiceError::InvalidRequest(format!(
+                "manual Deal SLI run would test {} URLs, limit is {}",
+                test_contexts.len(),
+                MAX_MANUAL_RUN_URL_TESTS
+            )));
+        }
+
+        let urls = test_contexts
+            .iter()
+            .map(|context| context.url.clone())
+            .collect::<Vec<_>>();
+        let url_results = test_urls_double_tap(&client, urls).await;
+
+        let successful_piece_indexes = test_contexts
+            .iter()
+            .zip(url_results.iter())
+            .filter_map(|(context, result)| result.success.then_some(context.piece_index))
+            .collect::<BTreeSet<_>>();
+        let large_piece_indexes = test_contexts
+            .iter()
+            .zip(url_results.iter())
+            .filter_map(|(context, result)| {
+                (result.content_length.unwrap_or_default() >= MIN_VALID_CONTENT_LENGTH)
+                    .then_some(context.piece_index)
+            })
+            .collect::<BTreeSet<_>>();
+        let car_piece_indexes = test_contexts
+            .iter()
+            .zip(url_results.iter())
+            .filter_map(|(context, result)| result.is_valid_car.then_some(context.piece_index))
+            .collect::<BTreeSet<_>>();
+
+        let piece_count = stored.pieces.len() as i32;
+        let success_count = successful_piece_indexes.len() as i32;
+        let failed_count = piece_count - success_count;
+        let result_code = if success_count == piece_count {
+            ResultCode::Success
+        } else {
+            ResultCode::FailedToGetWorkingUrl
+        };
+        let piece_results = test_contexts
+            .iter()
+            .zip(url_results.iter())
+            .map(|(context, result)| map_piece_result(deal_id, context, result))
+            .collect::<Vec<_>>();
+        let working_url = url_results
+            .iter()
+            .filter(|result| result.success)
+            .max_by_key(|result| result.content_length)
+            .map(|result| result.url.clone());
+
+        self.repo
+            .insert_completed_run_with_piece_results(&NewCompletedDealSliRun {
+                deal_id: deal_id.to_string(),
+                target_pieces: target_piece_snapshots(&stored.pieces),
+                measurement_state: MeasurementState::Fresh.as_str().to_string(),
+                provider_id: stored.target.provider_id.clone(),
+                client_id: stored.target.client_id.clone(),
+                working_url,
+                retrievability_percent: percent(success_count, piece_count),
+                large_files_percent: percent(large_piece_indexes.len() as i32, piece_count),
+                car_files_percent: percent(car_piece_indexes.len() as i32, piece_count),
+                sector_utilization_percent: None,
+                is_consistent: Some(url_results.iter().all(|result| result.consistent)),
+                is_reliable: Some(success_count == piece_count),
+                result_code,
+                piece_count,
+                success_count,
+                failed_count,
+                piece_results,
+            })
+            .await
+            .map_err(map_run_insert_error)
+    }
+}
+
+#[derive(Debug)]
+struct DealSliPieceTestContext {
+    piece_index: i32,
+    piece_cid: String,
+    url: String,
+}
+
+fn build_piece_test_contexts(
+    endpoints: &[String],
+    pieces: &[DealSliPiece],
+) -> Vec<DealSliPieceTestContext> {
+    endpoints
+        .iter()
+        .flat_map(|endpoint| {
+            let endpoint = endpoint.trim_end_matches('/');
+            pieces.iter().map(move |piece| DealSliPieceTestContext {
+                piece_index: piece.piece_index,
+                piece_cid: piece.piece_cid.clone(),
+                url: format!("{endpoint}/piece/{}", piece.piece_cid),
+            })
+        })
+        .collect()
+}
+
+fn target_piece_snapshots(pieces: &[DealSliPiece]) -> Vec<DealSliRunPieceSnapshot> {
+    pieces
+        .iter()
+        .map(|piece| DealSliRunPieceSnapshot {
+            piece_index: piece.piece_index,
+            piece_cid: piece.piece_cid.clone(),
+            piece_size_bytes: piece.piece_size_bytes.clone(),
+        })
+        .collect()
+}
+
+fn map_piece_result(
+    deal_id: &str,
+    context: &DealSliPieceTestContext,
+    result: &UrlTestResult,
+) -> NewDealSliPieceResult {
+    NewDealSliPieceResult {
+        deal_id: deal_id.to_string(),
+        piece_index: context.piece_index,
+        piece_cid: context.piece_cid.clone(),
+        url_tested: result.url.clone(),
+        success: result.success,
+        content_length: result
+            .content_length
+            .and_then(|value| i64::try_from(value).ok()),
+        is_valid_car: result.is_valid_car,
+        result_code: if result.success {
+            ResultCode::Success
+        } else {
+            ResultCode::FailedToGetWorkingUrl
+        },
+    }
+}
+
+fn percent(numerator: i32, denominator: i32) -> Option<BigDecimal> {
+    if denominator == 0 {
+        return None;
+    }
+
+    BigDecimal::from_str(&format!(
+        "{:.2}",
+        f64::from(numerator) * 100.0 / f64::from(denominator)
+    ))
+    .ok()
+}
+
+fn validate_deal_id(deal_id: &str) -> std::result::Result<(), DealSliServiceError> {
+    if deal_id.is_empty() || !deal_id.chars().all(|c| c.is_ascii_digit()) {
+        return Err(DealSliServiceError::InvalidRequest(format!(
+            "deal_id must be a decimal string, got {deal_id}"
+        )));
+    }
+
+    Ok(())
+}
+
+fn map_target_write_error(error: color_eyre::Report) -> DealSliServiceError {
+    let message = error.to_string();
+    if message.contains("deal SLI pieces contain duplicate")
+        || message.contains("deal SLI pieces cannot be added or removed")
+        || message.contains("cid or size cannot change")
+    {
+        return DealSliServiceError::InvalidRequest(message);
+    }
+
+    DealSliServiceError::Internal(error)
+}
+
+fn map_run_insert_error(error: color_eyre::Report) -> DealSliServiceError {
+    let message = error.to_string();
+    if message.contains("changed before run insertion") {
+        return DealSliServiceError::InvalidRequest(message);
+    }
+
+    DealSliServiceError::Internal(error)
+}
+
+fn parse_piece_size_bytes(value: String) -> std::result::Result<BigDecimal, DealSliServiceError> {
+    if value.is_empty() || !value.chars().all(|c| c.is_ascii_digit()) {
+        return Err(DealSliServiceError::InvalidRequest(
+            "piece_size_bytes must be a base-10 integer string".to_string(),
+        ));
+    }
+
+    value.parse::<BigDecimal>().map_err(|error| {
+        DealSliServiceError::InvalidRequest(format!(
+            "piece_size_bytes must be a base-10 integer string: {error}"
+        ))
+    })
+}
+
+fn u32_to_i32(value: u32, field: &str) -> std::result::Result<i32, DealSliServiceError> {
+    i32::try_from(value).map_err(|_| {
+        DealSliServiceError::InvalidRequest(format!(
+            "{field} must be less than or equal to i32::MAX"
+        ))
+    })
+}
+
+fn map_upsert_request(
+    deal_id: &str,
+    request: DealTargetUpsertRequest,
+) -> std::result::Result<NewDealSliTarget, DealSliServiceError> {
+    if request.pieces.is_empty() {
+        return Err(DealSliServiceError::InvalidRequest(
+            "pieces must not be empty".to_string(),
+        ));
+    }
+
+    let pieces = request
+        .pieces
+        .into_iter()
+        .enumerate()
+        .map(
+            |(index, piece)| -> std::result::Result<NewDealSliPiece, DealSliServiceError> {
+                let piece_size_bytes = piece
+                    .piece_size_bytes
+                    .map(parse_piece_size_bytes)
+                    .transpose()?;
+
+                Ok(NewDealSliPiece {
+                    piece_index: index as i32,
+                    piece_cid: piece.piece_cid,
+                    piece_size_bytes,
+                    allocation_id: piece.allocation_id,
+                    claim_id: piece.claim_id,
+                })
+            },
+        )
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    let requirements = match request.requirements {
+        Some(requirements) => DealSliRequirementValues {
+            retrievability_bps: Some(i32::from(requirements.retrievability_bps)),
+            bandwidth_mbps: requirements
+                .bandwidth_mbps
+                .map(|value| u32_to_i32(value, "bandwidth_mbps"))
+                .transpose()?,
+            latency_ms: requirements
+                .latency_ms
+                .map(|value| u32_to_i32(value, "latency_ms"))
+                .transpose()?,
+        },
+        None => DealSliRequirementValues::default(),
+    };
+
+    Ok(NewDealSliTarget {
+        deal_id: deal_id.to_string(),
+        deal_version: match request.deal_version {
+            DealVersion::V2 => "v2".to_string(),
+        },
+        provider_id: request.provider_id,
+        client_id: request.client,
+        manifest_hash: request.manifest_hash,
+        manifest_location: request.manifest_location,
+        requirements,
+        pieces,
+    })
+}
+
+fn map_target_response(stored: DealSliTargetWithPieces) -> DealTargetResponse {
+    DealTargetResponse {
+        deal_id: stored.target.deal_id,
+        deal_version: DealVersion::V2,
+        provider_id: Some(stored.target.provider_id),
+        client: stored.target.client_id,
+        manifest_hash: stored.target.manifest_hash,
+        manifest_location: stored.target.manifest_location,
+        requirements: map_requirements(
+            stored.target.retrievability_bps,
+            stored.target.bandwidth_mbps,
+            stored.target.latency_ms,
+        ),
+        pieces: stored
+            .pieces
+            .into_iter()
+            .map(|piece| DealPieceTarget {
+                piece_cid: piece.piece_cid,
+                piece_size_bytes: piece.piece_size_bytes.map(|value| value.to_string()),
+                allocation_id: piece.allocation_id,
+                claim_id: piece.claim_id,
+            })
+            .collect(),
+        created_at: Some(stored.target.created_at),
+        updated_at: Some(stored.target.updated_at),
+    }
+}
+
+fn map_requirements(
+    retrievability_bps: Option<i32>,
+    bandwidth_mbps: Option<i32>,
+    latency_ms: Option<i32>,
+) -> Option<DealSliRequirements> {
+    if retrievability_bps.is_none() && bandwidth_mbps.is_none() && latency_ms.is_none() {
+        return None;
+    }
+
+    Some(DealSliRequirements {
+        retrievability_bps: retrievability_bps.unwrap_or_default() as u16,
+        bandwidth_mbps: bandwidth_mbps.map(|value| value as u32),
+        latency_ms: latency_ms.map(|value| value as u32),
+    })
+}
+
+fn map_latest_response(run: DealSliLatestRun) -> DealLatestMeasurementResponse {
+    DealLatestMeasurementResponse {
+        deal_id: run.deal_id,
+        measurement_state: MeasurementState::from_db_value(&run.measurement_state),
+        tested_at: run.tested_at,
+        working_url: run.working_url,
+        retrievability_percent: run
+            .retrievability_percent
+            .as_ref()
+            .and_then(bigdecimal_to_f64),
+        large_files_percent: run.large_files_percent.as_ref().and_then(bigdecimal_to_f64),
+        car_files_percent: run.car_files_percent.as_ref().and_then(bigdecimal_to_f64),
+        sector_utilization_percent: run
+            .sector_utilization_percent
+            .as_ref()
+            .and_then(bigdecimal_to_f64),
+        is_consistent: run.is_consistent,
+        is_reliable: run.is_reliable,
+        result_code: run.result_code,
+        error_code: run.error_code,
+        piece_count: run.piece_count as u32,
+        success_count: run.success_count as u32,
+        failed_count: run.failed_count as u32,
+        performance: DealPerformanceResponse::default(),
+    }
+}
+
+fn bigdecimal_to_f64(value: &BigDecimal) -> Option<f64> {
+    value.to_string().parse().ok()
+}
+
+impl MeasurementState {
+    pub fn from_db_value(value: &str) -> Self {
+        match value {
+            "fresh" => Self::Fresh,
+            "stale" => Self::Stale,
+            "failed" => Self::Failed,
+            "skipped" => Self::Skipped,
+            _ => Self::Missing,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Missing => "missing",
+            Self::Fresh => "fresh",
+            Self::Stale => "stale",
+            Self::Failed => "failed",
+            Self::Skipped => "skipped",
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn _preserve_type_reachability(_: Option<ErrorCode>) {}

--- a/url_finder/src/services/deal_sli_service.rs
+++ b/url_finder/src/services/deal_sli_service.rs
@@ -370,6 +370,16 @@ fn u32_to_i32(value: u32, field: &str) -> std::result::Result<i32, DealSliServic
     })
 }
 
+fn retrievability_bps_to_i32(value: u16) -> std::result::Result<i32, DealSliServiceError> {
+    if value > 10_000 {
+        return Err(DealSliServiceError::InvalidRequest(
+            "retrievability_bps must be less than or equal to 10000".to_string(),
+        ));
+    }
+
+    Ok(i32::from(value))
+}
+
 fn map_upsert_request(
     deal_id: &str,
     request: DealTargetUpsertRequest,
@@ -404,7 +414,7 @@ fn map_upsert_request(
 
     let requirements = match request.requirements {
         Some(requirements) => DealSliRequirementValues {
-            retrievability_bps: Some(i32::from(requirements.retrievability_bps)),
+            retrievability_bps: Some(retrievability_bps_to_i32(requirements.retrievability_bps)?),
             bandwidth_mbps: requirements
                 .bandwidth_mbps
                 .map(|value| u32_to_i32(value, "bandwidth_mbps"))

--- a/url_finder/src/services/deal_sli_service.rs
+++ b/url_finder/src/services/deal_sli_service.rs
@@ -15,7 +15,7 @@ use crate::{
         DealSliRunPieceSnapshot, DealSliTargetWithPieces, NewCompletedDealSliRun, NewDealSliPiece,
         NewDealSliPieceResult, NewDealSliTarget, StorageProviderRepository,
     },
-    types::{ErrorCode, ProviderId, ResultCode, UrlTestResult},
+    types::{ErrorCode, ProviderAddress, ProviderId, ResultCode, UrlTestResult},
     url_tester::test_urls_double_tap,
 };
 
@@ -380,6 +380,19 @@ fn retrievability_bps_to_i32(value: u16) -> std::result::Result<i32, DealSliServ
     Ok(i32::from(value))
 }
 
+fn normalize_provider_id(value: String) -> std::result::Result<String, DealSliServiceError> {
+    if value.starts_with("f0") {
+        let address = ProviderAddress::new(value)
+            .map_err(|error| DealSliServiceError::InvalidRequest(format!("{error}")))?;
+        let id: ProviderId = address.into();
+        return Ok(id.as_str().to_string());
+    }
+
+    ProviderId::new(value)
+        .map(|id| id.as_str().to_string())
+        .map_err(|error| DealSliServiceError::InvalidRequest(format!("{error}")))
+}
+
 fn map_upsert_request(
     deal_id: &str,
     request: DealTargetUpsertRequest,
@@ -432,7 +445,7 @@ fn map_upsert_request(
         deal_version: match request.deal_version {
             DealVersion::V2 => "v2".to_string(),
         },
-        provider_id: request.provider_id,
+        provider_id: normalize_provider_id(request.provider_id)?,
         client_id: request.client,
         manifest_hash: request.manifest_hash,
         manifest_location: request.manifest_location,

--- a/url_finder/src/services/mod.rs
+++ b/url_finder/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod consistency_analyzer;
 pub mod deal_service;
+pub mod deal_sli_service;
 pub mod provider_service;
 pub mod url_discovery_service;

--- a/url_finder/tests/common/db_setup.rs
+++ b/url_finder/tests/common/db_setup.rs
@@ -76,6 +76,33 @@ pub async fn seed_provider(app_pool: &PgPool, provider_id: &str) {
     .expect("Failed to insert provider");
 }
 
+pub async fn seed_provider_with_cached_endpoints(
+    app_pool: &PgPool,
+    provider_id: &str,
+    cached_http_endpoints: &[String],
+) {
+    sqlx::query(
+        r#"INSERT INTO
+                storage_providers (
+                    provider_id,
+                    peer_id,
+                    cached_http_endpoints,
+                    endpoints_fetched_at
+                )
+           VALUES
+                ($1, 'test-peer-id', $2, NOW())
+           ON CONFLICT (provider_id) DO UPDATE SET
+                peer_id = EXCLUDED.peer_id,
+                cached_http_endpoints = EXCLUDED.cached_http_endpoints,
+                endpoints_fetched_at = EXCLUDED.endpoints_fetched_at"#,
+    )
+    .bind(provider_id)
+    .bind(cached_http_endpoints)
+    .execute(app_pool)
+    .await
+    .expect("Failed to insert provider with cached endpoints");
+}
+
 pub async fn seed_deals(
     app_pool: &PgPool,
     provider_id: &str,

--- a/url_finder/tests/common/test_app.rs
+++ b/url_finder/tests/common/test_app.rs
@@ -11,10 +11,10 @@ use url_finder::{
     AppState,
     config::Config,
     repository::{
-        BmsBandwidthResultRepository, DealRepository, StorageProviderRepository,
+        BmsBandwidthResultRepository, DealRepository, DealSliRepository, StorageProviderRepository,
         UrlResultRepository,
     },
-    services::provider_service::ProviderService,
+    services::{deal_sli_service::DealSliService, provider_service::ProviderService},
 };
 
 use super::{TestDatabases, mock_servers::MockExternalServices};
@@ -35,18 +35,26 @@ pub async fn create_test_app(dbs: &TestDatabases, mocks: &MockExternalServices) 
 
     let url_repo = Arc::new(UrlResultRepository::new(dbs.app_pool.clone()));
     let bms_repo = Arc::new(BmsBandwidthResultRepository::new(dbs.app_pool.clone()));
+    let deal_sli_repo = Arc::new(DealSliRepository::new(dbs.app_pool.clone()));
     let storage_provider_repo = Arc::new(StorageProviderRepository::new(dbs.app_pool.clone()));
     let provider_service = Arc::new(ProviderService::new(
         url_repo.clone(),
         bms_repo.clone(),
         storage_provider_repo.clone(),
     ));
+    let deal_sli_service = Arc::new(DealSliService::new(
+        deal_sli_repo.clone(),
+        storage_provider_repo.clone(),
+        config.clone(),
+    ));
 
     let app_state = Arc::new(AppState {
         deal_repo: Arc::new(DealRepository::new(dbs.app_pool.clone())),
+        deal_sli_repo,
         storage_provider_repo,
         url_repo,
         bms_repo,
+        deal_sli_service,
         provider_service,
         config,
     });

--- a/url_finder/tests/integration_tests/deal_sli_api.rs
+++ b/url_finder/tests/integration_tests/deal_sli_api.rs
@@ -1,0 +1,535 @@
+use assert_json_diff::assert_json_include;
+use axum::http::StatusCode;
+use serde_json::{Value, json};
+
+use crate::common::*;
+
+#[derive(sqlx::FromRow)]
+struct StoredDealSliRun {
+    state: String,
+    measurement_state: String,
+    result_code: Option<url_finder::ResultCode>,
+    piece_count: i32,
+    success_count: i32,
+    failed_count: i32,
+}
+
+#[derive(sqlx::FromRow)]
+struct StoredDealSliPieceResult {
+    piece_index: i32,
+    piece_cid: String,
+    url_tested: String,
+    success: bool,
+    result_code: Option<url_finder::ResultCode>,
+}
+
+fn deal_request() -> Value {
+    json!({
+        "deal_version": "v2",
+        "provider_id": "1234",
+        "client": "5678",
+        "manifest_hash": "bafy-manifest",
+        "manifest_location": "https://example.com/manifest.car",
+        "requirements": {
+            "retrievability_bps": 9500,
+            "bandwidth_mbps": 200,
+            "latency_ms": 150
+        },
+        "pieces": [
+            {
+                "piece_cid": "baga6ea4seaq",
+                "piece_size_bytes": "1024",
+                "allocation_id": "44",
+                "claim_id": "44"
+            },
+            {
+                "piece_cid": "baga6ea4sear",
+                "piece_size_bytes": "2048",
+                "allocation_id": "55",
+                "claim_id": "55"
+            }
+        ]
+    })
+}
+
+#[tokio::test]
+async fn test_put_deal_persists_and_get_deal_returns_stored_target() {
+    let ctx = TestContext::new().await;
+
+    let put_response = ctx
+        .app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&deal_request())
+        .await;
+
+    assert_eq!(put_response.status_code(), StatusCode::OK);
+
+    let get_response = ctx.app.get("/deals/123").await;
+
+    assert_eq!(get_response.status_code(), StatusCode::OK);
+    let body: Value = get_response.json();
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "deal_id": "123",
+            "deal_version": "v2",
+            "provider_id": "1234",
+            "client": "5678",
+            "manifest_hash": "bafy-manifest",
+            "manifest_location": "https://example.com/manifest.car",
+            "requirements": {
+                "retrievability_bps": 9500,
+                "bandwidth_mbps": 200,
+                "latency_ms": 150
+            },
+            "pieces": [
+                {
+                    "piece_cid": "baga6ea4seaq",
+                    "piece_size_bytes": "1024",
+                    "allocation_id": "44",
+                    "claim_id": "44"
+                },
+                {
+                    "piece_cid": "baga6ea4sear",
+                    "piece_size_bytes": "2048",
+                    "allocation_id": "55",
+                    "claim_id": "55"
+                }
+            ]
+        })
+    );
+    assert!(body.get("created_at").and_then(Value::as_str).is_some());
+    assert!(body.get("updated_at").and_then(Value::as_str).is_some());
+}
+
+#[tokio::test]
+async fn test_put_deal_with_invalid_decimal_deal_id_returns_bad_request() {
+    let ctx = TestContext::new().await;
+
+    let response = ctx
+        .app
+        .put("/deals/not-a-decimal")
+        .authorization_bearer("test-token")
+        .json(&deal_request())
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
+    let body: Value = response.json();
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "error_code": "INVALID_REQUEST"
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_put_deal_with_empty_pieces_returns_bad_request() {
+    let ctx = TestContext::new().await;
+    let mut request = deal_request();
+    request["pieces"] = json!([]);
+
+    let response = ctx
+        .app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&request)
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
+    let body: Value = response.json();
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "error_code": "INVALID_REQUEST"
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_put_deal_with_fractional_piece_size_returns_bad_request() {
+    let ctx = TestContext::new().await;
+    let mut request = deal_request();
+    request["pieces"][0]["piece_size_bytes"] = json!("1024.5");
+
+    let response = ctx
+        .app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&request)
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
+    let body: Value = response.json();
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "error_code": "INVALID_REQUEST"
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_put_deal_with_overflowing_requirement_returns_bad_request() {
+    let ctx = TestContext::new().await;
+    let mut request = deal_request();
+    request["requirements"]["bandwidth_mbps"] = json!(u32::MAX);
+
+    let response = ctx
+        .app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&request)
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
+    let body: Value = response.json();
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "error_code": "INVALID_REQUEST"
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_get_deal_returns_not_found_when_target_missing() {
+    let ctx = TestContext::new().await;
+
+    let response = ctx.app.get("/deals/123").await;
+
+    assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+    let body: Value = response.json();
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "error_code": "NOT_FOUND"
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_get_latest_returns_missing_state_with_target_piece_count_when_no_runs_exist() {
+    let ctx = TestContext::new().await;
+
+    ctx.app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&deal_request())
+        .await
+        .assert_status_ok();
+
+    let response = ctx.app.get("/deals/123/latest").await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+    let body: Value = response.json();
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "deal_id": "123",
+            "measurement_state": "missing",
+            "piece_count": 2,
+            "success_count": 0,
+            "failed_count": 0,
+            "result_code": null
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_get_latest_returns_not_found_when_target_missing() {
+    let ctx = TestContext::new().await;
+
+    let response = ctx.app.get("/deals/123/latest").await;
+
+    assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+    let body: Value = response.json();
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "error_code": "NOT_FOUND"
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_post_run_without_cached_endpoints_persists_failed_run_and_latest_uses_it() {
+    let ctx = TestContext::new().await;
+
+    ctx.app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&deal_request())
+        .await
+        .assert_status_ok();
+
+    seed_provider(&ctx.dbs.app_pool, "1234").await;
+
+    let run_response = ctx
+        .app
+        .post("/deals/123/runs")
+        .authorization_bearer("test-token")
+        .await;
+
+    assert_eq!(run_response.status_code(), StatusCode::OK);
+    let run_body: Value = run_response.json();
+    assert_json_include!(
+        actual: run_body,
+        expected: json!({
+            "deal_id": "123",
+            "measurement_state": "failed",
+            "piece_count": 2,
+            "success_count": 0,
+            "failed_count": 2,
+            "result_code": "MissingHttpAddrFromCidContact"
+        })
+    );
+    assert!(run_body.get("tested_at").and_then(Value::as_str).is_some());
+
+    let row = sqlx::query_as::<_, StoredDealSliRun>(
+        r#"SELECT
+                state,
+                measurement_state,
+                result_code,
+                piece_count,
+                success_count,
+                failed_count
+           FROM
+                deal_sli_runs
+           WHERE
+                deal_id = $1
+        "#,
+    )
+    .bind("123")
+    .fetch_one(&ctx.dbs.app_pool)
+    .await
+    .expect("stored run should exist");
+
+    assert_eq!(row.state, "completed");
+    assert_eq!(row.measurement_state, "failed");
+    assert_eq!(
+        row.result_code,
+        Some(url_finder::ResultCode::MissingHttpAddrFromCidContact)
+    );
+    assert_eq!(row.piece_count, 2);
+    assert_eq!(row.success_count, 0);
+    assert_eq!(row.failed_count, 2);
+
+    let latest_response = ctx.app.get("/deals/123/latest").await;
+
+    assert_eq!(latest_response.status_code(), StatusCode::OK);
+    let latest_body: Value = latest_response.json();
+    assert_json_include!(
+        actual: latest_body,
+        expected: json!({
+            "deal_id": "123",
+            "measurement_state": "failed",
+            "piece_count": 2,
+            "success_count": 0,
+            "failed_count": 2,
+            "result_code": "MissingHttpAddrFromCidContact"
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_post_run_with_cached_endpoint_tests_target_pieces_and_stores_piece_results() {
+    let ctx = TestContext::new().await;
+
+    ctx.app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&deal_request())
+        .await
+        .assert_status_ok();
+
+    ctx.mocks
+        .setup_piece_retrieval_mock("baga6ea4seaq", true)
+        .await;
+    ctx.mocks
+        .setup_piece_retrieval_mock("baga6ea4sear", false)
+        .await;
+    seed_provider_with_cached_endpoints(&ctx.dbs.app_pool, "1234", &[ctx.mocks.piece_server_url()])
+        .await;
+
+    let run_response = ctx
+        .app
+        .post("/deals/123/runs")
+        .authorization_bearer("test-token")
+        .await;
+
+    assert_eq!(run_response.status_code(), StatusCode::OK);
+    let run_body: Value = run_response.json();
+    assert_json_include!(
+        actual: run_body,
+        expected: json!({
+            "deal_id": "123",
+            "measurement_state": "fresh",
+            "retrievability_percent": 50.0,
+            "large_files_percent": 50.0,
+            "piece_count": 2,
+            "success_count": 1,
+            "failed_count": 1,
+            "result_code": "FailedToGetWorkingUrl"
+        })
+    );
+    assert!(
+        run_body
+            .get("working_url")
+            .and_then(Value::as_str)
+            .is_some_and(|url| url.ends_with("/piece/baga6ea4seaq"))
+    );
+
+    let piece_rows = sqlx::query_as::<_, StoredDealSliPieceResult>(
+        r#"SELECT
+                piece_index,
+                piece_cid,
+                url_tested,
+                success,
+                result_code
+           FROM
+                deal_sli_piece_results
+           WHERE
+                deal_id = $1
+           ORDER BY
+                piece_index ASC
+        "#,
+    )
+    .bind("123")
+    .fetch_all(&ctx.dbs.app_pool)
+    .await
+    .expect("piece result rows should load");
+
+    assert_eq!(piece_rows.len(), 2);
+    assert_eq!(piece_rows[0].piece_index, 0);
+    assert_eq!(piece_rows[0].piece_cid, "baga6ea4seaq");
+    assert!(piece_rows[0].success);
+    assert_eq!(
+        piece_rows[0].result_code,
+        Some(url_finder::ResultCode::Success)
+    );
+    assert!(piece_rows[0].url_tested.ends_with("/piece/baga6ea4seaq"));
+    assert_eq!(piece_rows[1].piece_index, 1);
+    assert_eq!(piece_rows[1].piece_cid, "baga6ea4sear");
+    assert!(!piece_rows[1].success);
+    assert_eq!(
+        piece_rows[1].result_code,
+        Some(url_finder::ResultCode::FailedToGetWorkingUrl)
+    );
+}
+
+#[tokio::test]
+async fn test_post_run_rejects_oversized_synchronous_fanout() {
+    let ctx = TestContext::new().await;
+
+    ctx.app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&deal_request())
+        .await
+        .assert_status_ok();
+
+    let endpoints = (0..257)
+        .map(|index| format!("http://127.0.0.1:{}/", 10_000 + index))
+        .collect::<Vec<_>>();
+    seed_provider_with_cached_endpoints(&ctx.dbs.app_pool, "1234", &endpoints).await;
+
+    let response = ctx
+        .app
+        .post("/deals/123/runs")
+        .authorization_bearer("test-token")
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
+    let body: Value = response.json();
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "error_code": "INVALID_REQUEST"
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_put_deal_rejects_piece_identity_change_after_no_endpoint_run_exists() {
+    let ctx = TestContext::new().await;
+
+    ctx.app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&deal_request())
+        .await
+        .assert_status_ok();
+
+    seed_provider(&ctx.dbs.app_pool, "1234").await;
+    ctx.app
+        .post("/deals/123/runs")
+        .authorization_bearer("test-token")
+        .await
+        .assert_status_ok();
+
+    let mut changed_request = deal_request();
+    changed_request["pieces"][0]["piece_cid"] = json!("baga6ea4seaz");
+
+    let response = ctx
+        .app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&changed_request)
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
+    let body: Value = response.json();
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "error_code": "INVALID_REQUEST"
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_put_deal_rejects_piece_identity_change_after_piece_results_exist() {
+    let ctx = TestContext::new().await;
+
+    ctx.app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&deal_request())
+        .await
+        .assert_status_ok();
+
+    ctx.mocks
+        .setup_piece_retrieval_mock("baga6ea4seaq", true)
+        .await;
+    ctx.mocks
+        .setup_piece_retrieval_mock("baga6ea4sear", false)
+        .await;
+    seed_provider_with_cached_endpoints(&ctx.dbs.app_pool, "1234", &[ctx.mocks.piece_server_url()])
+        .await;
+    ctx.app
+        .post("/deals/123/runs")
+        .authorization_bearer("test-token")
+        .await
+        .assert_status_ok();
+
+    let mut changed_request = deal_request();
+    changed_request["pieces"][0]["piece_cid"] = json!("baga6ea4seaz");
+
+    let response = ctx
+        .app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&changed_request)
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
+    let body: Value = response.json();
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "error_code": "INVALID_REQUEST"
+        })
+    );
+}

--- a/url_finder/tests/integration_tests/deal_sli_api.rs
+++ b/url_finder/tests/integration_tests/deal_sli_api.rs
@@ -194,6 +194,29 @@ async fn test_put_deal_with_overflowing_requirement_returns_bad_request() {
 }
 
 #[tokio::test]
+async fn test_put_deal_with_invalid_retrievability_requirement_returns_bad_request() {
+    let ctx = TestContext::new().await;
+    let mut request = deal_request();
+    request["requirements"]["retrievability_bps"] = json!(10_001);
+
+    let response = ctx
+        .app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&request)
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
+    let body: Value = response.json();
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "error_code": "INVALID_REQUEST"
+        })
+    );
+}
+
+#[tokio::test]
 async fn test_get_deal_returns_not_found_when_target_missing() {
     let ctx = TestContext::new().await;
 

--- a/url_finder/tests/integration_tests/deal_sli_api.rs
+++ b/url_finder/tests/integration_tests/deal_sli_api.rs
@@ -52,6 +52,30 @@ fn deal_request() -> Value {
     })
 }
 
+fn many_piece_deal_request(piece_count: usize) -> Value {
+    let pieces = (0..piece_count)
+        .map(|index| {
+            json!({
+                "piece_cid": format!("baga6ea4seaq{index:04}"),
+                "piece_size_bytes": "34359738368"
+            })
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "deal_version": "v2",
+        "provider_id": "1234",
+        "client": "5678",
+        "manifest_location": "https://example.com/large-manifest.json",
+        "requirements": {
+            "retrievability_bps": 9500,
+            "bandwidth_mbps": 200,
+            "latency_ms": 150
+        },
+        "pieces": pieces
+    })
+}
+
 #[tokio::test]
 async fn test_put_deal_persists_and_get_deal_returns_stored_target() {
     let ctx = TestContext::new().await;
@@ -508,7 +532,7 @@ async fn test_post_run_with_cached_endpoint_tests_target_pieces_and_stores_piece
             "piece_count": 2,
             "success_count": 1,
             "failed_count": 1,
-            "result_code": "FailedToGetWorkingUrl"
+            "result_code": "Success"
         })
     );
     assert!(
@@ -557,6 +581,56 @@ async fn test_post_run_with_cached_endpoint_tests_target_pieces_and_stores_piece
 }
 
 #[tokio::test]
+async fn test_post_run_allows_large_single_endpoint_deal() {
+    let ctx = TestContext::new().await;
+
+    ctx.app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&many_piece_deal_request(1_499))
+        .await
+        .assert_status_ok();
+
+    seed_provider_with_cached_endpoints(&ctx.dbs.app_pool, "1234", &[ctx.mocks.piece_server_url()])
+        .await;
+
+    let response = ctx
+        .app
+        .post("/deals/123/runs")
+        .authorization_bearer("test-token")
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+    let body: Value = response.json();
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "deal_id": "123",
+            "measurement_state": "fresh",
+            "piece_count": 1499,
+            "success_count": 0,
+            "failed_count": 1499,
+            "result_code": "FailedToGetWorkingUrl"
+        })
+    );
+
+    let piece_result_count: i64 = sqlx::query_scalar(
+        r#"SELECT COUNT(*)
+           FROM
+                deal_sli_piece_results
+           WHERE
+                deal_id = $1
+        "#,
+    )
+    .bind("123")
+    .fetch_one(&ctx.dbs.app_pool)
+    .await
+    .expect("piece result count should load");
+
+    assert_eq!(piece_result_count, 1_499);
+}
+
+#[tokio::test]
 async fn test_post_run_rejects_oversized_synchronous_fanout() {
     let ctx = TestContext::new().await;
 
@@ -567,7 +641,7 @@ async fn test_post_run_rejects_oversized_synchronous_fanout() {
         .await
         .assert_status_ok();
 
-    let endpoints = (0..257)
+    let endpoints = (0..1025)
         .map(|index| format!("http://127.0.0.1:{}/", 10_000 + index))
         .collect::<Vec<_>>();
     seed_provider_with_cached_endpoints(&ctx.dbs.app_pool, "1234", &endpoints).await;

--- a/url_finder/tests/integration_tests/deal_sli_api.rs
+++ b/url_finder/tests/integration_tests/deal_sli_api.rs
@@ -104,6 +104,46 @@ async fn test_put_deal_persists_and_get_deal_returns_stored_target() {
 }
 
 #[tokio::test]
+async fn test_put_deal_accepts_provider_address_and_stores_provider_id() {
+    let ctx = TestContext::new().await;
+    let mut request = deal_request();
+    request["provider_id"] = json!("f01234");
+
+    let put_response = ctx
+        .app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&request)
+        .await;
+
+    assert_eq!(put_response.status_code(), StatusCode::OK);
+    let put_body: Value = put_response.json();
+    assert_json_include!(
+        actual: put_body,
+        expected: json!({
+            "provider_id": "1234"
+        })
+    );
+
+    seed_provider(&ctx.dbs.app_pool, "1234").await;
+    let run_response = ctx
+        .app
+        .post("/deals/123/runs")
+        .authorization_bearer("test-token")
+        .await;
+
+    assert_eq!(run_response.status_code(), StatusCode::OK);
+    let run_body: Value = run_response.json();
+    assert_json_include!(
+        actual: run_body,
+        expected: json!({
+            "measurement_state": "failed",
+            "result_code": "MissingHttpAddrFromCidContact"
+        })
+    );
+}
+
+#[tokio::test]
 async fn test_put_deal_with_invalid_decimal_deal_id_returns_bad_request() {
     let ctx = TestContext::new().await;
 
@@ -112,6 +152,29 @@ async fn test_put_deal_with_invalid_decimal_deal_id_returns_bad_request() {
         .put("/deals/not-a-decimal")
         .authorization_bearer("test-token")
         .json(&deal_request())
+        .await;
+
+    assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
+    let body: Value = response.json();
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "error_code": "INVALID_REQUEST"
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_put_deal_with_invalid_provider_id_returns_bad_request() {
+    let ctx = TestContext::new().await;
+    let mut request = deal_request();
+    request["provider_id"] = json!("f01abc");
+
+    let response = ctx
+        .app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&request)
         .await;
 
     assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
@@ -272,6 +335,57 @@ async fn test_get_latest_returns_not_found_when_target_missing() {
         actual: body,
         expected: json!({
             "error_code": "NOT_FOUND"
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_get_latest_uses_stable_tie_breaker_for_matching_timestamps() {
+    let ctx = TestContext::new().await;
+
+    ctx.app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&deal_request())
+        .await
+        .assert_status_ok();
+
+    sqlx::query(
+        r#"INSERT INTO
+                deal_sli_runs (
+                    id,
+                    deal_id,
+                    state,
+                    measurement_state,
+                    started_at,
+                    completed_at,
+                    tested_at,
+                    provider_id,
+                    result_code,
+                    piece_count,
+                    success_count,
+                    failed_count
+                )
+           VALUES
+                ('00000000-0000-0000-0000-000000000001', '123', 'completed', 'failed', '2026-06-03 10:00:00+00', '2026-06-03 10:00:00+00', '2026-06-03 10:00:00+00', '1234', 'FailedToGetWorkingUrl', 2, 0, 2),
+                ('00000000-0000-0000-0000-000000000002', '123', 'completed', 'fresh', '2026-06-03 10:00:00+00', '2026-06-03 10:00:00+00', '2026-06-03 10:00:00+00', '1234', 'Success', 2, 2, 0)
+        "#,
+    )
+    .execute(&ctx.dbs.app_pool)
+    .await
+    .expect("tied runs should insert");
+
+    let response = ctx.app.get("/deals/123/latest").await;
+
+    assert_eq!(response.status_code(), StatusCode::OK);
+    let body: Value = response.json();
+    assert_json_include!(
+        actual: body,
+        expected: json!({
+            "measurement_state": "fresh",
+            "result_code": "Success",
+            "success_count": 2,
+            "failed_count": 0
         })
     );
 }

--- a/url_finder/tests/integration_tests/deals_auth.rs
+++ b/url_finder/tests/integration_tests/deals_auth.rs
@@ -1,4 +1,3 @@
-use assert_json_diff::assert_json_include;
 use axum::http::StatusCode;
 use serde_json::{Value, json};
 
@@ -7,21 +6,13 @@ use crate::common::*;
 fn deal_request() -> Value {
     json!({
         "deal_version": "v2",
-        "provider_id": "f01234",
-        "client": "f05678",
-        "manifest_hash": "bafy-manifest",
-        "manifest_location": "https://example.com/manifest.car",
-        "requested_size_bytes": "2048",
-        "requirements": {
-            "retrievability_bps": 9500,
-            "bandwidth_mbps": 200,
-            "latency_ms": 150
-        },
+        "provider_id": "1234",
+        "client": "5678",
         "pieces": [{
             "piece_cid": "baga6ea4seaq",
             "piece_size_bytes": "1024",
             "allocation_id": "44",
-            "claim_id": "55"
+            "claim_id": "44"
         }]
     })
 }
@@ -87,67 +78,27 @@ async fn test_put_deal_with_wrong_auth_rejects_before_json_parsing() {
 }
 
 #[tokio::test]
-async fn test_put_deal_with_correct_auth_returns_shell_response() {
+async fn test_post_run_without_auth_returns_unauthorized() {
+    let ctx = TestContext::new().await;
+
+    let response = ctx.app.post("/deals/123/runs").await;
+
+    assert_eq!(response.status_code(), StatusCode::UNAUTHORIZED);
+    let body: Value = response.json();
+    assert_eq!(body, json!({ "error": "Unauthorized" }));
+}
+
+#[tokio::test]
+async fn test_post_run_with_wrong_auth_returns_unauthorized() {
     let ctx = TestContext::new().await;
 
     let response = ctx
         .app
-        .put("/deals/123")
-        .authorization_bearer("test-token")
-        .json(&deal_request())
+        .post("/deals/123/runs")
+        .authorization_bearer("wrong-token")
         .await;
 
-    assert_eq!(response.status_code(), StatusCode::OK);
+    assert_eq!(response.status_code(), StatusCode::UNAUTHORIZED);
     let body: Value = response.json();
-
-    assert_json_include!(
-        actual: body,
-        expected: json!({
-            "deal_id": "123",
-            "deal_version": "v2",
-            "provider_id": "f01234",
-            "manifest_hash": "bafy-manifest",
-            "pieces": [{
-                "piece_cid": "baga6ea4seaq",
-                "claim_id": "55"
-            }]
-        })
-    );
-}
-
-#[tokio::test]
-async fn test_get_deal_remains_public() {
-    let ctx = TestContext::new().await;
-
-    let response = ctx.app.get("/deals/123").await;
-
-    assert_eq!(response.status_code(), StatusCode::OK);
-    let body: Value = response.json();
-    assert_json_include!(
-        actual: body,
-        expected: json!({
-            "deal_id": "123",
-            "deal_version": "v2"
-        })
-    );
-}
-
-#[tokio::test]
-async fn test_get_latest_deal_measurement_remains_public() {
-    let ctx = TestContext::new().await;
-
-    let response = ctx.app.get("/deals/123/latest").await;
-
-    assert_eq!(response.status_code(), StatusCode::OK);
-    let body: Value = response.json();
-    assert_json_include!(
-        actual: body,
-        expected: json!({
-            "deal_id": "123",
-            "measurement_state": "missing",
-            "piece_count": 0,
-            "success_count": 0,
-            "failed_count": 0
-        })
-    );
+    assert_eq!(body, json!({ "error": "Unauthorized" }));
 }

--- a/url_finder/tests/integration_tests/mod.rs
+++ b/url_finder/tests/integration_tests/mod.rs
@@ -1,6 +1,7 @@
 pub mod bms_client;
 pub mod bms_result_repo;
 pub mod clients_providers;
+pub mod deal_sli_api;
 pub mod deals_auth;
 pub mod extended_response;
 pub mod find_client;


### PR DESCRIPTION
Implements Deal SLI on separate `deal_sli_*` tables.

- stores deal targets and pieces separately from `url_results`
- persists latest run state, including no-endpoint failed runs
- adds manual cached-endpoint runs with per-piece results
- freezes piece identity after a run exists