### PR TITLE
Add Deal SLI scheduler and BMS result ingestion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,18 +1,33 @@
-## Writable RPA application database. Migrations and deal_sli_* writes use this DB.
+# Writable RPA application database. Migrations, provider cache, URL results,
+# BMS results, and deal_sli_* writes use this database.
 DATABASE_URL=postgres://postgres:pgpassword@localhost:5434/uf
-## Read-only DMOB deal source database. For local fake-DMOB development this may
-## point at the same local Postgres as DATABASE_URL. For mainnet-seeded testing,
-## point it at the host SSH tunnel URL and run the app with cargo on the host.
+
+# Read-only DMOB deal source database. For local fake-DMOB development this may
+# point at the same local Postgres as DATABASE_URL. For mainnet-seeded testing,
+# point it at the host SSH tunnel URL and run the app with cargo on the host.
 DMOB_DATABASE_URL=postgres://postgres:pgpassword@localhost:5434/uf
 
-# URL for GLIF RPC endpoint
-GLIF_URL=https://api.node.glif.io/rpc/v1
+# Application logging.
+LOG_LEVEL=debug
 
+# External Filecoin and endpoint-discovery services.
+GLIF_URL=https://api.node.glif.io/rpc/v1
+CID_CONTACT_URL=https://cid.contact
+
+# Optional proxy settings for endpoint tests.
 PROXY_URL=
 PROXY_USER=
 PROXY_PASSWORD=
+PROXY_DEFAULT_PORT=
+PROXY_IP_COUNT=
 
-# BMS Configuration
+# Deal SLI write endpoints require Authorization: Bearer <AUTH_TOKEN>.
+AUTH_TOKEN=dev-token
+
+# BMS configuration used by provider-level checks and Deal SLI bandwidth jobs.
 BMS_URL=https://bms.allocator.tech
 BMS_WORKER_COUNT=10
 BMS_TEST_INTERVAL_DAYS=7
+
+# Provider discovery concurrency. Values outside 1..=100 fall back to 10.
+MAX_CONCURRENT_PROVIDERS=10

--- a/.sqlx/query-4adb44f9bc828e3e62ac56688cd18615087d3ed120d9f5ca348712cb1dea5d9d.json
+++ b/.sqlx/query-4adb44f9bc828e3e62ac56688cd18615087d3ed120d9f5ca348712cb1dea5d9d.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH due AS (\n                    SELECT\n                        deal_id\n                    FROM\n                        deal_sli_target_schedules\n                    WHERE\n                        next_run_at <= NOW()\n                    ORDER BY\n                        next_run_at ASC,\n                        deal_id ASC\n                    LIMIT $1\n                    FOR UPDATE SKIP LOCKED\n                )\n                UPDATE\n                    deal_sli_target_schedules schedules\n                SET\n                    next_run_at = NOW() + make_interval(days => $2::int),\n                    updated_at = NOW()\n                FROM\n                    due\n                WHERE\n                    schedules.deal_id = due.deal_id\n                RETURNING\n                    schedules.deal_id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "deal_id",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "4adb44f9bc828e3e62ac56688cd18615087d3ed120d9f5ca348712cb1dea5d9d"
+}

--- a/.sqlx/query-63ab164f21401d113f82b37a061af90b0dbbc8cee446e8cd0bc634596fb5b206.json
+++ b/.sqlx/query-63ab164f21401d113f82b37a061af90b0dbbc8cee446e8cd0bc634596fb5b206.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE\n                    deal_sli_bms_jobs\n               SET\n                    status = $2,\n                    ping_avg_ms = $3,\n                    head_avg_ms = $4,\n                    ttfb_ms = $5,\n                    download_speed_mbps = $6,\n                    error_message = $7,\n                    completed_at = NOW()\n               WHERE\n                    bms_job_id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Numeric",
+        "Numeric",
+        "Numeric",
+        "Numeric",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "63ab164f21401d113f82b37a061af90b0dbbc8cee446e8cd0bc634596fb5b206"
+}

--- a/.sqlx/query-66b32b9ee14a54203906a4076cd168632b381b06423f9277f99eb3d543fde20d.json
+++ b/.sqlx/query-66b32b9ee14a54203906a4076cd168632b381b06423f9277f99eb3d543fde20d.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO\n                    deal_sli_target_schedules (deal_id)\n               VALUES\n                    ($1)\n               ON CONFLICT (deal_id) DO NOTHING\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "66b32b9ee14a54203906a4076cd168632b381b06423f9277f99eb3d543fde20d"
+}

--- a/.sqlx/query-72b38813e13c175852e4a6138bf95eef63dbaf8af2db16f3ab32966f610bc2c7.json
+++ b/.sqlx/query-72b38813e13c175852e4a6138bf95eef63dbaf8af2db16f3ab32966f610bc2c7.json
@@ -1,0 +1,126 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO\n                    deal_sli_bms_jobs (\n                        deal_id,\n                        run_id,\n                        piece_index,\n                        piece_cid,\n                        bms_job_id,\n                        url_tested,\n                        routing_key,\n                        worker_count,\n                        status\n                    )\n               VALUES\n                    ($1, $2, $3, $4, $5, $6, $7, $8, $9)\n               ON CONFLICT (bms_job_id) DO UPDATE SET\n                    status = EXCLUDED.status\n               RETURNING\n                    id,\n                    deal_id,\n                    run_id,\n                    piece_index,\n                    piece_cid,\n                    bms_job_id,\n                    url_tested,\n                    routing_key,\n                    worker_count,\n                    status,\n                    ping_avg_ms,\n                    head_avg_ms,\n                    ttfb_ms,\n                    download_speed_mbps,\n                    error_message,\n                    created_at,\n                    completed_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "deal_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "run_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "piece_index",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "piece_cid",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "bms_job_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 6,
+        "name": "url_tested",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "routing_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "worker_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "ping_avg_ms",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 11,
+        "name": "head_avg_ms",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 12,
+        "name": "ttfb_ms",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 13,
+        "name": "download_speed_mbps",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 14,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Uuid",
+        "Int4",
+        "Text",
+        "Uuid",
+        "Text",
+        "Varchar",
+        "Int4",
+        "Varchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "72b38813e13c175852e4a6138bf95eef63dbaf8af2db16f3ab32966f610bc2c7"
+}

--- a/.sqlx/query-ad4415a7e44548d78d5a557b51af239f0ce9265f87bd71f2f0061c7f4f470c98.json
+++ b/.sqlx/query-ad4415a7e44548d78d5a557b51af239f0ce9265f87bd71f2f0061c7f4f470c98.json
@@ -1,0 +1,118 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n                    id,\n                    deal_id,\n                    run_id,\n                    piece_index,\n                    piece_cid,\n                    bms_job_id,\n                    url_tested,\n                    routing_key,\n                    worker_count,\n                    status,\n                    ping_avg_ms,\n                    head_avg_ms,\n                    ttfb_ms,\n                    download_speed_mbps,\n                    error_message,\n                    created_at,\n                    completed_at\n               FROM\n                    deal_sli_bms_jobs\n               WHERE\n                    run_id = $1\n               ORDER BY\n                    piece_index ASC,\n                    created_at ASC,\n                    id ASC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "deal_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "run_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "piece_index",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "piece_cid",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "bms_job_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 6,
+        "name": "url_tested",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "routing_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "worker_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "ping_avg_ms",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 11,
+        "name": "head_avg_ms",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 12,
+        "name": "ttfb_ms",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 13,
+        "name": "download_speed_mbps",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 14,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "ad4415a7e44548d78d5a557b51af239f0ce9265f87bd71f2f0061c7f4f470c98"
+}

--- a/.sqlx/query-f283e5876504c1cef769e82e8cdd2cdc830b852ca7b3bd2f4d719dc94c13fa9e.json
+++ b/.sqlx/query-f283e5876504c1cef769e82e8cdd2cdc830b852ca7b3bd2f4d719dc94c13fa9e.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n                    result.run_id,\n                    result.deal_id,\n                    result.piece_index,\n                    result.piece_cid,\n                    result.url_tested\n               FROM\n                    deal_sli_piece_results result\n               WHERE\n                    result.run_id = $1\n                    AND result.success\n                    AND NOT EXISTS (\n                        SELECT\n                            1\n                        FROM\n                            deal_sli_bms_jobs job\n                        WHERE\n                            job.run_id = result.run_id\n                            AND job.piece_index = result.piece_index\n                            AND job.url_tested = result.url_tested\n                    )\n               ORDER BY\n                    result.piece_index ASC,\n                    result.url_tested ASC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "run_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "deal_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "piece_index",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "piece_cid",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "url_tested",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "f283e5876504c1cef769e82e8cdd2cdc830b852ca7b3bd2f4d719dc94c13fa9e"
+}

--- a/.sqlx/query-f5d34cb99e727c753f91eadc81ae1cbb8fa6d6f827f7f15176010091f6d993f6.json
+++ b/.sqlx/query-f5d34cb99e727c753f91eadc81ae1cbb8fa6d6f827f7f15176010091f6d993f6.json
@@ -1,0 +1,116 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT\n                    id,\n                    deal_id,\n                    run_id,\n                    piece_index,\n                    piece_cid,\n                    bms_job_id,\n                    url_tested,\n                    routing_key,\n                    worker_count,\n                    status,\n                    ping_avg_ms,\n                    head_avg_ms,\n                    ttfb_ms,\n                    download_speed_mbps,\n                    error_message,\n                    created_at,\n                    completed_at\n               FROM\n                    deal_sli_bms_jobs\n               WHERE\n                    status = 'Pending'\n               ORDER BY\n                    created_at ASC,\n                    id ASC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "deal_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "run_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "piece_index",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "piece_cid",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "bms_job_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 6,
+        "name": "url_tested",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "routing_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "worker_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "ping_avg_ms",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 11,
+        "name": "head_avg_ms",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 12,
+        "name": "ttfb_ms",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 13,
+        "name": "download_speed_mbps",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 14,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "f5d34cb99e727c753f91eadc81ae1cbb8fa6d6f827f7f15176010091f6d993f6"
+}

--- a/.sqlx/query-f5e97fa378f31fefd177f11009bfdc95b7da574cf9a5d738afefaaee3605d386.json
+++ b/.sqlx/query-f5e97fa378f31fefd177f11009bfdc95b7da574cf9a5d738afefaaee3605d386.json
@@ -1,95 +1,100 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT\n                    deal_id,\n                    measurement_state,\n                    tested_at,\n                    working_url,\n                    retrievability_percent,\n                    large_files_percent,\n                    car_files_percent,\n                    sector_utilization_percent,\n                    manifest_snapshot_id,\n                    deal_size_bytes,\n                    manifest_size_bytes,\n                    content_matches_deal,\n                    sampled_piece_count,\n                    size_matched_percent,\n                    avg_response_time_ms,\n                    is_consistent,\n                    is_reliable,\n                    result_code AS \"result_code: ResultCode\",\n                    error_code AS \"error_code: ErrorCode\",\n                    piece_count,\n                    success_count,\n                    failed_count\n               FROM\n                    deal_sli_runs\n               WHERE\n                    deal_id = $1\n                    AND state = 'completed'\n               ORDER BY\n                    completed_at DESC NULLS LAST,\n                    started_at DESC,\n                    id DESC\n               LIMIT\n                    1\n            ",
+  "query": "SELECT\n                    id,\n                    deal_id,\n                    measurement_state,\n                    tested_at,\n                    working_url,\n                    retrievability_percent,\n                    large_files_percent,\n                    car_files_percent,\n                    sector_utilization_percent,\n                    manifest_snapshot_id,\n                    deal_size_bytes,\n                    manifest_size_bytes,\n                    content_matches_deal,\n                    sampled_piece_count,\n                    size_matched_percent,\n                    avg_response_time_ms,\n                    is_consistent,\n                    is_reliable,\n                    result_code AS \"result_code: ResultCode\",\n                    error_code AS \"error_code: ErrorCode\",\n                    piece_count,\n                    success_count,\n                    failed_count\n               FROM\n                    deal_sli_runs\n               WHERE\n                    deal_id = $1\n                    AND state = 'completed'\n               ORDER BY\n                    completed_at DESC NULLS LAST,\n                    started_at DESC,\n                    id DESC\n               LIMIT\n                    1\n            ",
   "describe": {
     "columns": [
       {
         "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
         "name": "deal_id",
         "type_info": "Text"
       },
       {
-        "ordinal": 1,
+        "ordinal": 2,
         "name": "measurement_state",
         "type_info": "Text"
       },
       {
-        "ordinal": 2,
+        "ordinal": 3,
         "name": "tested_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 3,
+        "ordinal": 4,
         "name": "working_url",
         "type_info": "Text"
       },
       {
-        "ordinal": 4,
+        "ordinal": 5,
         "name": "retrievability_percent",
         "type_info": "Numeric"
       },
       {
-        "ordinal": 5,
+        "ordinal": 6,
         "name": "large_files_percent",
         "type_info": "Numeric"
       },
       {
-        "ordinal": 6,
+        "ordinal": 7,
         "name": "car_files_percent",
         "type_info": "Numeric"
       },
       {
-        "ordinal": 7,
+        "ordinal": 8,
         "name": "sector_utilization_percent",
         "type_info": "Numeric"
       },
       {
-        "ordinal": 8,
+        "ordinal": 9,
         "name": "manifest_snapshot_id",
         "type_info": "Uuid"
       },
       {
-        "ordinal": 9,
+        "ordinal": 10,
         "name": "deal_size_bytes",
         "type_info": "Numeric"
       },
       {
-        "ordinal": 10,
+        "ordinal": 11,
         "name": "manifest_size_bytes",
         "type_info": "Numeric"
       },
       {
-        "ordinal": 11,
+        "ordinal": 12,
         "name": "content_matches_deal",
         "type_info": "Bool"
       },
       {
-        "ordinal": 12,
+        "ordinal": 13,
         "name": "sampled_piece_count",
         "type_info": "Int4"
       },
       {
-        "ordinal": 13,
+        "ordinal": 14,
         "name": "size_matched_percent",
         "type_info": "Numeric"
       },
       {
-        "ordinal": 14,
+        "ordinal": 15,
         "name": "avg_response_time_ms",
         "type_info": "Numeric"
       },
       {
-        "ordinal": 15,
+        "ordinal": 16,
         "name": "is_consistent",
         "type_info": "Bool"
       },
       {
-        "ordinal": 16,
+        "ordinal": 17,
         "name": "is_reliable",
         "type_info": "Bool"
       },
       {
-        "ordinal": 17,
+        "ordinal": 18,
         "name": "result_code: ResultCode",
         "type_info": {
           "Custom": {
@@ -112,7 +117,7 @@
         }
       },
       {
-        "ordinal": 18,
+        "ordinal": 19,
         "name": "error_code: ErrorCode",
         "type_info": {
           "Custom": {
@@ -130,17 +135,17 @@
         }
       },
       {
-        "ordinal": 19,
+        "ordinal": 20,
         "name": "piece_count",
         "type_info": "Int4"
       },
       {
-        "ordinal": 20,
+        "ordinal": 21,
         "name": "success_count",
         "type_info": "Int4"
       },
       {
-        "ordinal": 21,
+        "ordinal": 22,
         "name": "failed_count",
         "type_info": "Int4"
       }
@@ -151,6 +156,7 @@
       ]
     },
     "nullable": [
+      false,
       false,
       false,
       true,
@@ -175,5 +181,5 @@
       false
     ]
   },
-  "hash": "db5194460d1ac6f196a2bc730dd237d9d249031ab59fd022965ace18cbc10e05"
+  "hash": "f5e97fa378f31fefd177f11009bfdc95b7da574cf9a5d738afefaaee3605d386"
 }

--- a/README.md
+++ b/README.md
@@ -1,94 +1,92 @@
 # Random Piece Availability measurement
 
-## Introduction
+Random Piece Availability (RPA) measures whether Filecoin storage provider data
+is retrievable over HTTP. It discovers provider endpoints, tests piece URLs, and
+stores retrievability and bandwidth results for consumers that need current
+provider or deal-level availability data.
 
-The Random Piece Availability (or RPA) is a microservice designed to test the retrievability of files claimed by Storage Providers (SPs) on the Filecoin network. Its primary goal is to verify whether files associated with deals are accessible via HTTP endpoints advertised by SPs. This service focuses exclusively on HTTP retrievability.
+The service also exposes the Deal SLI API used by PoRep Market. PoRep Market can
+register a deal target with a manifest location and manifest hash. RPA fetches
+and verifies that manifest, derives the deal pieces from it, measures sampled
+piece retrievability against cached provider endpoints, and stores the latest
+deal SLI state for oracle or market integrations.
 
-## Table of Contents
+## Running Locally
 
-- [Development](#development)
-  - [Environment Variables](#environment-variables)
-  - [Result Codes](#result-codes)
-  - [Error Codes](#error-codes)
-- [How the Service Works](#how-the-service-works)
-  - [Two types of Requests](#two-types-of-requests)
-  - [High-Level Workflow](#high-level-workflow)
-  - [Design Choices](#design-choices)
-- [Potential Issues](#potential-issues)
-- [Possible Improvements](#possible-improvements)
+Create a local environment file from the example:
+
+```bash
+cp .env.example .env
+```
+
+Start Postgres, run migrations, and seed local development data:
+
+```bash
+make init-dev
+```
+
+Run the service in Docker:
+
+```bash
+make run
+```
+
+For SSH-tunneled DMOB testing, start only Postgres with `make run-db` and run
+the Rust binary on the host so `DMOB_DATABASE_URL` can point at the tunnel.
+Configuration fields and local defaults are documented in `.env.example`.
+
+The application listens on port `3010`:
+
+- Swagger UI: `http://localhost:3010/`
+- OpenAPI JSON: `http://localhost:3010/api-doc/openapi.json`
+- Healthcheck: `http://localhost:3010/healthcheck`
+
+## How The Service Works
+
+RPA keeps two related measurement flows.
+
+The provider flow discovers HTTP endpoints for storage providers and measures
+retrievability for pieces selected from the deal database. It gets provider peer
+IDs from Lotus RPC, fetches advertised endpoints from `cid.contact` and filspark,
+tests piece URLs, and stores provider-level retrievability, URL, and BMS metrics.
+
+The Deal SLI flow is deal-first. A caller registers a PoRep deal target through
+the Deal SLI API. The target includes the provider, optional client, deal size,
+manifest hash, manifest URL, and optional SLI requirements. RPA verifies the
+manifest hash, stores a manifest snapshot, derives the measurable pieces, and
+then records scheduled or manually triggered measurements for that deal.
+
+Deal SLI measurements use ranged GET checks against cached provider endpoints.
+The latest response reports deal state, retrievability, manifest size matching,
+piece counts, a working URL when one was found, and BMS-derived PoRep SLI values
+when bandwidth jobs have completed.
+
+## API Overview
+
+Swagger is the source of truth for request and response fields. The main API
+groups are:
+
+- `/deals/*` - Deal SLI API for PoRep Market and oracle integrations.
+- `/providers/*` and `/clients/*` - provider and client views over stored
+  retrievability, URL, and BMS data.
+- `/url/*` - legacy URL Finder endpoints.
+
+Write endpoints in the Deal SLI API require bearer authentication. Set
+`AUTH_TOKEN` in `.env`; Swagger labels those endpoints with `bearer_auth`.
 
 ## Development
 
-### Environment Variables
+Common commands:
 
-- `DATABASE_URL` - writable RPA application database. Migrations, provider cache,
-  URL results, BMS results, and `deal_sli_*` tables use this database.
-- `DMOB_DATABASE_URL` - read-only DMOB deal source database used for deal lookup.
-  For local fake-DMOB development it may point at the same local Postgres as
-  `DATABASE_URL`. For testing against a host SSH tunnel, run Postgres in Docker
-  and run `cargo run --bin url_finder` on the host so
-  `DMOB_DATABASE_URL=postgres://...@localhost:<tunnel-port>/...` resolves
-  through the tunnel.
+```bash
+make init-dev
+make run
+make test
+make prepare
+```
 
-The Docker app service is for local fake-DMOB development and points both
-database URLs at the Compose Postgres service. For SSH-tunneled DMOB testing,
-start only Postgres with `make run-db` and run the Rust binary on the host.
+`make prepare` runs SQLx prepare, formatting, and clippy. Run it before pushing
+or opening a PR.
 
-### Result Codes
-
-- `NoCidContactData` - There is not data in `cid.contact` given `peer_id`
-- `MissingAddrFromCidContact` - There are no addresses in `ExtendedProviders` in `cid.contact` response
-- `MissingHttpAddrFromCidContact` - There are no http addresses in `ExtendedProviders` in `cid.contact` response
-- `NoDealsFound` - No deals found for the given SP address
-- `FailedToGetWorkingUrl` - No working URLs found
-- `Success` - The URL was found successfully and is returned with the response
-
-### Error Codes
-
-- `FailedToGetPeerId` - Failed to get the peer ID from the lotus rpc
-- `FailedToRetrieveCidContactData` - Failed to retrieve the miner info from the database
-
-## How the Service Works
-
-### Two types of Requests
-
-1. **Async Job**: User requests a job, which is processed in the background. The user receives a `job_id` that is used to check the status and results later. The jobs are processed one by one, allowing for multiple jobs to be created without blocking the service.
-2. **Direct Call**: User requests measurement in synchronous mode, which is processed immediately. The result is not stored or cached and its returned as a response to the request. Response might take up to several minutes and might time out if the request takes too long.
-
-### High-Level Workflow 
-
-1. **Input**: The service accepts requests for a Storage Provider address, a Client address, or both.
-1. **SP Endpoint Discovery**: For each SP, the service:
-   - Retrieves the peer ID using Lotus RPC (`Filecoin.StateMinerInfo`)
-   - Calls [cid.contact](https://cid.contact) for HTTP endpoints associated with the peer ID (from `ExtendedProviders` section)
-   - Parses multiaddresses to extract usable HTTP endpoints
-1. **Deal and PieceCID Selection**:
-   - Calls the database for deals matching the SP (and optionally the client)
-   - Selects up to `100` **random** pieceCIDs per SP/client pair to ensure a representative sample
-1. **URL Construction**:
-   - Constructs URLs by combining each HTTP endpoint with each pieceCID (`http://{HTTP_ENPOINT}/piece/{pieceCID}`)
-1. **Retrievability Testing**:
-   - Concurrently tests up to `20` URLs at a time using HTTP HEAD requests
-   - Records which URLs are reachable (return a successful HTTP response)
-   - Saves one working URL and calculates the retrievability percentage (working URLs / total tested)
-1. **Result**:
-   - Returns/Saves the working URL and retrievability percentage
-   - Provides detailed result codes and error codes when applicable
-
-### Design Choices
-
-- **Random Sampling**: Testing a random subset of pieceCIDs ensures that retrievability metrics are not biased by deal ordering or selection
-- **Async Job**: Using async jobs allows the process to run in the background, mitigating timeouts and allowing to create multiple jobs at once that will be processed one by one
-- **External Data Sources**: Lotus RPC and cid.contact are authoritative sources for miner info and endpoints
-
-## Potential Issues
-
-- **HTTP Endpoint Reliability**: Not all SPs maintain reliable or up-to-date HTTP endpoints.
-- **HEAD Requests Only**: HEAD requests check for basic reachability, but do not guarantee that the file can be fully downloaded or is valid
-
-## Possible Improvements
-
-1. **Scheduled Checks**: Implement a scheduler to periodically re-check URLs for retrievability, ensuring that the data remains current
-1. **Database Integration**: Store results in a database to allow for faster response times
-1. **File Header Analysis**: Extend the service to analyze file headers for additional metadata e.g. size, diff between deal size and actual file size
-1. **Historical Metrics**: Track retrievability metrics over time for trend analysis
+Integration tests use testcontainers for Postgres and wiremock for external HTTP
+services.

--- a/migrations/20260610120000_add_deal_sli_scheduler_bms_jobs.down.sql
+++ b/migrations/20260610120000_add_deal_sli_scheduler_bms_jobs.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS deal_sli_bms_jobs;
+
+DROP TABLE IF EXISTS deal_sli_target_schedules;

--- a/migrations/20260610120000_add_deal_sli_scheduler_bms_jobs.up.sql
+++ b/migrations/20260610120000_add_deal_sli_scheduler_bms_jobs.up.sql
@@ -1,0 +1,49 @@
+CREATE TABLE deal_sli_target_schedules (
+    deal_id TEXT PRIMARY KEY REFERENCES deal_sli_targets(deal_id) ON DELETE CASCADE,
+    next_run_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO
+    deal_sli_target_schedules (deal_id)
+SELECT
+    deal_id
+FROM
+    deal_sli_targets
+ON CONFLICT (deal_id) DO NOTHING;
+
+CREATE INDEX idx_deal_sli_target_schedules_next_run
+    ON deal_sli_target_schedules (next_run_at, deal_id);
+
+CREATE TABLE deal_sli_bms_jobs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    deal_id TEXT NOT NULL,
+    run_id UUID NOT NULL,
+    piece_index INTEGER NOT NULL,
+    piece_cid TEXT NOT NULL,
+    bms_job_id UUID NOT NULL UNIQUE,
+    url_tested TEXT NOT NULL,
+    routing_key VARCHAR(50) NOT NULL,
+    worker_count INTEGER NOT NULL,
+    status VARCHAR(50) NOT NULL,
+    ping_avg_ms NUMERIC(10, 3),
+    head_avg_ms NUMERIC(10, 3),
+    ttfb_ms NUMERIC(10, 3),
+    download_speed_mbps NUMERIC(10, 2),
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    FOREIGN KEY (run_id, deal_id)
+        REFERENCES deal_sli_runs(id, deal_id) ON DELETE CASCADE,
+    FOREIGN KEY (deal_id, piece_index)
+        REFERENCES deal_sli_pieces(deal_id, piece_index),
+    CONSTRAINT deal_sli_bms_jobs_piece_index_check CHECK (piece_index >= 0),
+    CONSTRAINT deal_sli_bms_jobs_worker_count_check CHECK (worker_count >= 0)
+);
+
+CREATE INDEX idx_deal_sli_bms_jobs_deal_run
+    ON deal_sli_bms_jobs (deal_id, run_id);
+
+CREATE INDEX idx_deal_sli_bms_jobs_status
+    ON deal_sli_bms_jobs (status, created_at);

--- a/url_finder/src/api/api_doc.rs
+++ b/url_finder/src/api/api_doc.rs
@@ -124,6 +124,8 @@ The `/url/*` endpoints remain fully backward compatible.
             DealPieceTarget,
             DealTargetUpsertRequest,
             DealTargetResponse,
+            DealPorepSliResponse,
+            DealBmsResultResponse,
             DealLatestMeasurementResponse,
 
             // Misc

--- a/url_finder/src/api/api_doc.rs
+++ b/url_finder/src/api/api_doc.rs
@@ -24,9 +24,18 @@ impl Modify for SecurityAddon {
     info(
         title = "Url Finder",
         description = r#"
-This is the API documentation for the Url Finder micro-service.
+This is the API documentation for the Random Piece Availability service.
 
-The Url Finder service is responsible for finding the URL of a miner given its address.
+RPA discovers HTTP endpoints for Filecoin storage providers, measures piece
+retrievability, stores provider and BMS results, and exposes deal-level SLI
+state for PoRep Market integrations.
+
+## Deal SLI API
+
+The `/deals/*` endpoints are the PoRep Market contract surface. Register a
+deal target with a verified manifest, fetch the stored target and derived
+pieces, read the latest measurement state, or trigger a manual run. Deal SLI
+write endpoints require `Authorization: Bearer <AUTH_TOKEN>`.
 
 ## New Providers API
 

--- a/url_finder/src/api/deals/create_run.rs
+++ b/url_finder/src/api/deals/create_run.rs
@@ -16,7 +16,7 @@ use crate::{
 #[utoipa::path(
     post,
     path = "/deals/{deal_id}/runs",
-    description = "Persist a manual synchronous Deal SLI run result and return the stored latest run data.",
+    description = "Run a synchronous Deal SLI measurement for a stored target using cached provider endpoints, persist the result, and return the latest deal state.",
     params(DealPath),
     responses(
         (status = 200, description = "Stored latest deal run", body = DealLatestMeasurementResponse),

--- a/url_finder/src/api/deals/types.rs
+++ b/url_finder/src/api/deals/types.rs
@@ -115,9 +115,48 @@ pub struct DealLatestMeasurementResponse {
     pub is_reliable: Option<bool>,
     pub result_code: Option<ResultCode>,
     pub error_code: Option<UrlErrorCode>,
+    pub porep_slis: DealPorepSliResponse,
+    #[serde(default)]
+    pub bms_results: Vec<DealBmsResultResponse>,
     pub piece_count: u32,
     pub success_count: u32,
     pub failed_count: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DealPorepSliResponse {
+    pub retrievability_bps: Option<u16>,
+    pub bandwidth_mbps: Option<u32>,
+    pub latency_ms: Option<u32>,
+    pub indexing_pct: Option<u8>,
+}
+
+impl DealPorepSliResponse {
+    pub fn empty() -> Self {
+        Self {
+            retrievability_bps: None,
+            bandwidth_mbps: None,
+            latency_ms: None,
+            indexing_pct: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DealBmsResultResponse {
+    pub piece_index: u32,
+    pub piece_cid: String,
+    pub bms_job_id: String,
+    pub url_tested: String,
+    pub routing_key: String,
+    pub worker_count: u32,
+    pub status: String,
+    pub ping_avg_ms: Option<f64>,
+    pub head_avg_ms: Option<f64>,
+    pub ttfb_ms: Option<f64>,
+    pub download_speed_mbps: Option<f64>,
+    pub error_message: Option<String>,
+    pub completed_at: Option<DateTime<Utc>>,
 }
 
 impl DealLatestMeasurementResponse {
@@ -142,6 +181,8 @@ impl DealLatestMeasurementResponse {
             is_reliable: None,
             result_code: None,
             error_code: None,
+            porep_slis: DealPorepSliResponse::empty(),
+            bms_results: vec![],
             piece_count,
             success_count: 0,
             failed_count: 0,
@@ -217,6 +258,13 @@ mod tests {
                 "is_reliable": null,
                 "result_code": null,
                 "error_code": null,
+                "porep_slis": {
+                    "retrievability_bps": null,
+                    "bandwidth_mbps": null,
+                    "latency_ms": null,
+                    "indexing_pct": null
+                },
+                "bms_results": [],
                 "piece_count": 0,
                 "success_count": 0,
                 "failed_count": 0

--- a/url_finder/src/api/deals/types.rs
+++ b/url_finder/src/api/deals/types.rs
@@ -1,11 +1,15 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+#[allow(unused_imports)]
+use serde_json::json;
 use utoipa::{IntoParams, ToSchema};
 
 use crate::types::{ErrorCode as UrlErrorCode, ResultCode};
 
 #[derive(Debug, Clone, Deserialize, ToSchema, IntoParams)]
 pub struct DealPath {
+    /// Decimal Filecoin deal ID.
+    #[schema(example = "1234567890")]
     #[param(value_type = String)]
     pub deal_id: String,
 }
@@ -30,68 +34,143 @@ pub enum MeasurementState {
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct DealSliRequirements {
+    /// Required retrievability in basis points. `10000` means 100%.
+    #[schema(example = 9500, minimum = 0, maximum = 10000)]
     pub retrievability_bps: u16,
+    /// Optional minimum bandwidth requirement for completed BMS jobs.
+    #[schema(example = 200)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bandwidth_mbps: Option<u32>,
+    /// Optional maximum latency requirement derived from BMS time-to-first-byte.
+    #[schema(example = 150)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub latency_ms: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct DealPieceTarget {
+    /// Piece CID derived from the fetched manifest. Callers do not submit this field.
+    #[schema(example = "baga6ea4seaq")]
     pub piece_cid: String,
+    /// Piece size from the manifest, serialized as a base-10 integer string.
+    #[schema(example = "34359738368")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub piece_size_bytes: Option<String>,
+    /// File size from the manifest, serialized as a base-10 integer string.
+    #[schema(example = "16000000000")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub file_size_bytes: Option<String>,
+    /// Root CID from the manifest, when present.
+    #[schema(example = "bafybeigdyrzt5sfp7udm7hu76uh7y26dvdwfk4dciwqz2aue3nbxtyr7vm")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub root_cid: Option<String>,
+    /// Storage path from the manifest, when present.
+    #[schema(example = "piece.car")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_path: Option<String>,
+    /// Manifest piece type, when present.
+    #[schema(example = "dag")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub piece_type: Option<String>,
+    /// Allocation ID reserved for future chain-backed target metadata.
+    #[schema(example = "12345")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allocation_id: Option<String>,
+    /// Claim ID reserved for future chain-backed target metadata.
+    #[schema(example = "67890")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub claim_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[schema(example = json!({
+    "deal_version": "v2",
+    "provider_id": "f01234",
+    "client": "f05678",
+    "deal_size_bytes": "7112600059904",
+    "manifest_hash": "43ff1a93b66d742e9f9efc3305acaa51c9297b7000145f35e968e2b42e7bf328",
+    "manifest_location": "https://example.com/manifest.json",
+    "requirements": {
+        "retrievability_bps": 9500,
+        "bandwidth_mbps": 200,
+        "latency_ms": 150
+    }
+}))]
 #[serde(deny_unknown_fields)]
 pub struct DealTargetUpsertRequest {
+    /// Deal contract version. Only `v2` is accepted.
     #[serde(default)]
     pub deal_version: DealVersion,
+    /// Storage provider ID. Accepts `f01234` or `1234`; responses normalize to `1234`.
+    #[schema(example = "f01234")]
     pub provider_id: String,
+    /// Optional client ID associated with the deal.
+    #[schema(example = "f05678")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client: Option<String>,
+    /// Deal size in bytes, serialized as a base-10 integer string.
+    #[schema(example = "7112600059904")]
     pub deal_size_bytes: String,
+    /// Expected SHA-256 hash of the manifest body. A leading `0x` is accepted.
+    #[schema(example = "43ff1a93b66d742e9f9efc3305acaa51c9297b7000145f35e968e2b42e7bf328")]
     pub manifest_hash: String,
+    /// HTTP or HTTPS URL of the PoRep manifest to fetch and snapshot.
+    #[schema(example = "https://example.com/manifest.json")]
     pub manifest_location: String,
+    /// Optional SLI thresholds expected by PoRep Market.
+    #[schema(inline)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requirements: Option<DealSliRequirements>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct DealManifestSnapshotResponse {
+    /// Internal manifest snapshot ID.
+    #[schema(example = "018f6fd1-64f8-7c30-9e0f-f43a1d8df9b1")]
     pub id: String,
+    /// Verified manifest hash stored for this snapshot.
+    #[schema(example = "43ff1a93b66d742e9f9efc3305acaa51c9297b7000145f35e968e2b42e7bf328")]
     pub manifest_hash: String,
+    /// Manifest URL fetched for this snapshot.
+    #[schema(example = "https://example.com/manifest.json")]
     pub manifest_location: String,
+    /// Time when RPA fetched and stored this manifest.
     pub fetched_at: DateTime<Utc>,
+    /// Raw manifest body length in bytes.
+    #[schema(example = 2048)]
     pub content_byte_length: i64,
+    /// Number of pieces derived from the manifest.
+    #[schema(example = 2)]
     pub piece_count: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct DealTargetResponse {
+    /// Decimal Filecoin deal ID.
+    #[schema(example = "1234567890")]
     pub deal_id: String,
     pub deal_version: DealVersion,
+    /// Normalized provider ID without the `f0` prefix.
+    #[schema(example = "1234")]
     pub provider_id: Option<String>,
+    /// Optional client ID associated with the deal.
+    #[schema(example = "f05678")]
     pub client: Option<String>,
+    /// Deal size in bytes, serialized as a base-10 integer string.
+    #[schema(example = "7112600059904")]
     pub deal_size_bytes: Option<String>,
+    /// Verified manifest hash stored for the active target.
+    #[schema(example = "43ff1a93b66d742e9f9efc3305acaa51c9297b7000145f35e968e2b42e7bf328")]
     pub manifest_hash: Option<String>,
+    /// Manifest URL fetched for the active target.
+    #[schema(example = "https://example.com/manifest.json")]
     pub manifest_location: Option<String>,
+    /// Active manifest snapshot used to derive pieces.
     pub manifest_snapshot: Option<DealManifestSnapshotResponse>,
+    /// Optional SLI thresholds expected by PoRep Market.
+    #[schema(inline)]
     pub requirements: Option<DealSliRequirements>,
+    /// Pieces derived from the active manifest snapshot.
     #[serde(default)]
     pub pieces: Vec<DealPieceTarget>,
     pub created_at: Option<DateTime<Utc>>,
@@ -100,34 +179,72 @@ pub struct DealTargetResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct DealLatestMeasurementResponse {
+    /// Decimal Filecoin deal ID.
+    #[schema(example = "1234567890")]
     pub deal_id: String,
+    /// Latest measurement state for the stored target.
     pub measurement_state: MeasurementState,
+    /// Time when the latest run tested the target.
     pub tested_at: Option<DateTime<Utc>>,
+    /// Largest size-matched piece URL found in the latest run.
+    #[schema(example = "https://provider.example/piece/baga6ea4seaq")]
     pub working_url: Option<String>,
+    /// Percent of sampled pieces that returned any retrievable response.
+    #[schema(example = 50.0)]
     pub retrievability_percent: Option<f64>,
+    /// Manifest snapshot measured by the latest run.
+    #[schema(example = "018f6fd1-64f8-7c30-9e0f-f43a1d8df9b1")]
     pub manifest_snapshot_id: Option<String>,
+    /// Deal size in bytes, serialized as a base-10 integer string.
+    #[schema(example = "7112600059904")]
     pub deal_size_bytes: Option<String>,
+    /// Sum of manifest file sizes, serialized as a base-10 integer string.
+    #[schema(example = "7112600059904")]
     pub manifest_size_bytes: Option<String>,
+    /// Whether `deal_size_bytes` exactly equals the sum of manifest file sizes.
+    #[schema(example = true)]
     pub content_matches_deal: Option<bool>,
+    /// Number of manifest pieces sampled in the latest run.
+    #[schema(example = 100)]
     pub sampled_piece_count: Option<u32>,
+    /// Percent of sampled pieces whose observed size matched manifest `fileSize`.
+    #[schema(example = 50.0)]
     pub size_matched_percent: Option<f64>,
+    /// Average response time across successful ranged GET checks.
+    #[schema(example = 125.0)]
     pub avg_response_time_ms: Option<f64>,
+    /// Legacy reliability flag for URL checks, when available.
     pub is_reliable: Option<bool>,
     pub result_code: Option<ResultCode>,
     pub error_code: Option<UrlErrorCode>,
+    /// PoRep-facing SLI values derived from retrievability and completed BMS jobs.
     pub porep_slis: DealPorepSliResponse,
+    /// Completed or pending BMS jobs linked to successful piece URLs for this run.
     #[serde(default)]
     pub bms_results: Vec<DealBmsResultResponse>,
+    /// Total manifest piece count for the target.
+    #[schema(example = 250)]
     pub piece_count: u32,
+    /// Number of sampled pieces with exact size-matched responses.
+    #[schema(example = 50)]
     pub success_count: u32,
+    /// Number of sampled pieces without exact size-matched responses.
+    #[schema(example = 50)]
     pub failed_count: u32,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct DealPorepSliResponse {
+    /// Retrievability basis points derived from latest run percentage.
+    #[schema(example = 5000)]
     pub retrievability_bps: Option<u16>,
+    /// Minimum completed BMS download speed across linked piece jobs.
+    #[schema(example = 500)]
     pub bandwidth_mbps: Option<u32>,
+    /// Maximum completed BMS time-to-first-byte across linked piece jobs.
+    #[schema(example = 100)]
     pub latency_ms: Option<u32>,
+    /// Reserved for future indexing SLI support.
     pub indexing_pct: Option<u8>,
 }
 
@@ -144,18 +261,42 @@ impl DealPorepSliResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct DealBmsResultResponse {
+    /// Manifest piece index measured by this BMS job.
+    #[schema(example = 0)]
     pub piece_index: u32,
+    /// Piece CID measured by this BMS job.
+    #[schema(example = "baga6ea4seaq")]
     pub piece_cid: String,
+    /// BMS job UUID.
+    #[schema(example = "018f6fd1-64f8-7c30-9e0f-f43a1d8df9b1")]
     pub bms_job_id: String,
+    /// Piece URL submitted to BMS.
+    #[schema(example = "https://provider.example/piece/baga6ea4seaq")]
     pub url_tested: String,
+    /// BMS routing key returned by the job API.
+    #[schema(example = "us_east")]
     pub routing_key: String,
+    /// Number of BMS workers requested.
+    #[schema(example = 10)]
     pub worker_count: u32,
+    /// BMS job status.
+    #[schema(example = "Completed")]
     pub status: String,
+    /// Average ping from completed BMS worker data.
+    #[schema(example = 25.0)]
     pub ping_avg_ms: Option<f64>,
+    /// Average HEAD latency from completed BMS worker data.
+    #[schema(example = 50.0)]
     pub head_avg_ms: Option<f64>,
+    /// Time to first byte from completed BMS worker data.
+    #[schema(example = 100.0)]
     pub ttfb_ms: Option<f64>,
+    /// Download speed from completed BMS worker data.
+    #[schema(example = 500.0)]
     pub download_speed_mbps: Option<f64>,
+    /// Timeout or BMS error details, when the job failed locally.
     pub error_message: Option<String>,
+    /// Completion timestamp when the BMS job reached a terminal state.
     pub completed_at: Option<DateTime<Utc>>,
 }
 

--- a/url_finder/src/api/deals/upsert_deal.rs
+++ b/url_finder/src/api/deals/upsert_deal.rs
@@ -16,7 +16,7 @@ use crate::{
 #[utoipa::path(
     put,
     path = "/deals/{deal_id}",
-    description = "Create or update a persisted Deal SLI target and its measurable pieces.",
+    description = "Create or update a PoRep Deal SLI target. The service fetches manifest_location, verifies manifest_hash, derives pieces from the manifest, and stores the active manifest snapshot. Callers must not submit pieces directly.",
     request_body = DealTargetUpsertRequest,
     params(DealPath),
     responses(

--- a/url_finder/src/background/bms_scheduler.rs
+++ b/url_finder/src/background/bms_scheduler.rs
@@ -340,7 +340,7 @@ async fn process_completed_job(
     Ok(())
 }
 
-fn extract_results_from_job(
+pub(super) fn extract_results_from_job(
     job_response: &BmsJobResponse,
 ) -> (Option<f64>, Option<f64>, Option<f64>, Option<f64>) {
     // Find the last completed subjob with worker data (typically the 100% test)

--- a/url_finder/src/background/deal_sli_scheduler.rs
+++ b/url_finder/src/background/deal_sli_scheduler.rs
@@ -1,0 +1,291 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use color_eyre::{Result, eyre::eyre};
+use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, warn};
+
+use super::bms_scheduler::extract_results_from_job;
+use crate::{
+    bms_client::BmsClient,
+    circuit_breaker::CircuitBreaker,
+    config::Config,
+    repository::{DealSliBmsJobCompletion, DealSliRepository, NewDealSliBmsJob},
+    services::deal_sli_service::{DealSliService, DealSliServiceError},
+};
+
+const DEAL_SLI_SCHEDULER_INTERVAL: Duration = Duration::from_secs(300);
+const DEAL_SLI_SCHEDULER_CATCHUP_INTERVAL: Duration = Duration::from_secs(30);
+const DEAL_SLI_BMS_RESULT_POLLER_INTERVAL: Duration = Duration::from_secs(30);
+const DEAL_SLI_SCHEDULER_BATCH_SIZE: i64 = 25;
+const DEAL_SLI_BMS_JOB_TIMEOUT_HOURS: i64 = 48;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DealSliSchedulerStats {
+    pub targets_processed: usize,
+    pub bms_jobs_created: usize,
+}
+
+pub async fn run_deal_sli_scheduler(
+    config: Arc<Config>,
+    deal_sli_service: Arc<DealSliService>,
+    deal_sli_repo: Arc<DealSliRepository>,
+    bms_client: Arc<BmsClient>,
+    circuit_breaker: Arc<CircuitBreaker>,
+    shutdown: CancellationToken,
+) {
+    info!("Starting Deal SLI scheduler");
+
+    loop {
+        let interval = match run_deal_sli_scheduler_once(
+            &config,
+            &deal_sli_service,
+            &deal_sli_repo,
+            &bms_client,
+            &circuit_breaker,
+        )
+        .await
+        {
+            Ok(stats) if stats.targets_processed > 0 => {
+                info!(
+                    "Deal SLI scheduler processed {} targets and created {} BMS jobs",
+                    stats.targets_processed, stats.bms_jobs_created
+                );
+                DEAL_SLI_SCHEDULER_CATCHUP_INTERVAL
+            }
+            Ok(_) => {
+                debug!("No Deal SLI targets due for measurement");
+                DEAL_SLI_SCHEDULER_INTERVAL
+            }
+            Err(error) => {
+                error!("Deal SLI scheduler failed: {:?}", error);
+                DEAL_SLI_SCHEDULER_INTERVAL
+            }
+        };
+
+        tokio::select! {
+            _ = sleep(interval) => {}
+            _ = shutdown.cancelled() => {
+                info!("Deal SLI scheduler received shutdown signal");
+                break;
+            }
+        }
+    }
+
+    info!("Deal SLI scheduler stopped");
+}
+
+pub async fn run_deal_sli_bms_result_poller(
+    deal_sli_repo: Arc<DealSliRepository>,
+    bms_client: Arc<BmsClient>,
+    circuit_breaker: Arc<CircuitBreaker>,
+    shutdown: CancellationToken,
+) {
+    info!("Starting Deal SLI BMS result poller");
+
+    loop {
+        if let Err(error) =
+            run_deal_sli_bms_result_poller_once(&deal_sli_repo, &bms_client, &circuit_breaker).await
+        {
+            error!("Deal SLI BMS result poller failed: {:?}", error);
+        }
+
+        tokio::select! {
+            _ = sleep(DEAL_SLI_BMS_RESULT_POLLER_INTERVAL) => {}
+            _ = shutdown.cancelled() => {
+                info!("Deal SLI BMS result poller received shutdown signal");
+                break;
+            }
+        }
+    }
+
+    info!("Deal SLI BMS result poller stopped");
+}
+
+pub async fn run_deal_sli_bms_result_poller_once(
+    deal_sli_repo: &DealSliRepository,
+    bms_client: &BmsClient,
+    circuit_breaker: &CircuitBreaker,
+) -> Result<usize> {
+    let pending_jobs = deal_sli_repo.get_pending_deal_sli_bms_jobs().await?;
+    let mut completed_jobs = 0;
+
+    debug!("Polling {} pending Deal SLI BMS jobs", pending_jobs.len());
+
+    for job in pending_jobs {
+        if is_deal_sli_bms_job_timed_out(&job.created_at) {
+            let hours = (Utc::now() - job.created_at).num_hours();
+            let error_message = format!("BMS job timed out after {hours} hours");
+            warn!(
+                "Deal SLI BMS job {} for deal {} run {} piece {} timed out after {} hours",
+                job.bms_job_id, job.deal_id, job.run_id, job.piece_cid, hours
+            );
+            deal_sli_repo
+                .update_deal_sli_bms_job_completed(&DealSliBmsJobCompletion {
+                    job_id: job.bms_job_id,
+                    status: "Timeout",
+                    ping_avg_ms: None,
+                    head_avg_ms: None,
+                    ttfb_ms: None,
+                    download_speed_mbps: None,
+                    error_message: Some(&error_message),
+                })
+                .await?;
+            completed_jobs += 1;
+            continue;
+        }
+
+        if let Err(error) = circuit_breaker.check_allowed() {
+            debug!(
+                "BMS circuit breaker open, skipping Deal SLI BMS job {}: {}",
+                job.bms_job_id, error
+            );
+            continue;
+        }
+
+        match bms_client.get_job(job.bms_job_id).await {
+            Ok(job_response) => {
+                circuit_breaker.record_success();
+
+                if BmsClient::is_job_finished(&job_response.status) {
+                    let (ping_avg_ms, head_avg_ms, ttfb_ms, download_speed_mbps) =
+                        extract_results_from_job(&job_response);
+                    deal_sli_repo
+                        .update_deal_sli_bms_job_completed(&DealSliBmsJobCompletion {
+                            job_id: job.bms_job_id,
+                            status: &job_response.status,
+                            ping_avg_ms,
+                            head_avg_ms,
+                            ttfb_ms,
+                            download_speed_mbps,
+                            error_message: None,
+                        })
+                        .await?;
+                    completed_jobs += 1;
+                } else {
+                    debug!(
+                        "Deal SLI BMS job {} for deal {} run {} piece {} still in progress: {}",
+                        job.bms_job_id, job.deal_id, job.run_id, job.piece_cid, job_response.status
+                    );
+                }
+            }
+            Err(error) => {
+                circuit_breaker.record_failure();
+                warn!(
+                    "Failed to fetch Deal SLI BMS job {} for deal {} run {} piece {}: {:?}",
+                    job.bms_job_id, job.deal_id, job.run_id, job.piece_cid, error
+                );
+            }
+        }
+    }
+
+    Ok(completed_jobs)
+}
+
+fn is_deal_sli_bms_job_timed_out(created_at: &chrono::DateTime<Utc>) -> bool {
+    (Utc::now() - *created_at).num_hours() >= DEAL_SLI_BMS_JOB_TIMEOUT_HOURS
+}
+
+pub async fn run_deal_sli_scheduler_once(
+    config: &Config,
+    deal_sli_service: &DealSliService,
+    deal_sli_repo: &DealSliRepository,
+    bms_client: &BmsClient,
+    circuit_breaker: &CircuitBreaker,
+) -> Result<DealSliSchedulerStats> {
+    let interval_days = i32::try_from(config.bms_test_interval_days)
+        .map_err(|_| eyre!("BMS test interval days exceeds i32::MAX"))?;
+    let worker_count = i32::try_from(config.bms_default_worker_count)
+        .map_err(|_| eyre!("BMS worker count exceeds i32::MAX"))?;
+    let deal_ids = deal_sli_repo
+        .claim_due_scheduled_targets(DEAL_SLI_SCHEDULER_BATCH_SIZE, interval_days)
+        .await?;
+
+    let mut stats = DealSliSchedulerStats {
+        targets_processed: deal_ids.len(),
+        bms_jobs_created: 0,
+    };
+
+    for deal_id in deal_ids {
+        deal_sli_service
+            .create_run(&deal_id)
+            .await
+            .map_err(map_deal_sli_error)?;
+
+        let Some(run) = deal_sli_repo.get_latest_completed_run(&deal_id).await? else {
+            warn!("Deal SLI scheduler created no completed run for deal {deal_id}");
+            continue;
+        };
+
+        let piece_results = deal_sli_repo
+            .get_successful_piece_results_without_bms_jobs(run.id)
+            .await?;
+
+        for piece_result in piece_results {
+            if let Err(error) = circuit_breaker.check_allowed() {
+                warn!(
+                    "BMS circuit breaker open, skipping deal {} run {} piece {}: {}",
+                    piece_result.deal_id, piece_result.run_id, piece_result.piece_cid, error
+                );
+                continue;
+            }
+
+            let entity = format!(
+                "porep-deal:{}:run:{}:piece:{}",
+                piece_result.deal_id, piece_result.run_id, piece_result.piece_cid
+            );
+
+            match bms_client
+                .create_job(
+                    piece_result.url_tested.clone(),
+                    config.bms_default_worker_count,
+                    Some(entity),
+                )
+                .await
+            {
+                Ok(job) => {
+                    circuit_breaker.record_success();
+                    deal_sli_repo
+                        .insert_deal_sli_bms_job(&NewDealSliBmsJob {
+                            deal_id: piece_result.deal_id,
+                            run_id: piece_result.run_id,
+                            piece_index: piece_result.piece_index,
+                            piece_cid: piece_result.piece_cid,
+                            bms_job_id: job.id,
+                            url_tested: job.url,
+                            routing_key: job.routing_key,
+                            worker_count,
+                            status: job.status,
+                        })
+                        .await?;
+                    stats.bms_jobs_created += 1;
+                }
+                Err(error) => {
+                    circuit_breaker.record_failure();
+                    warn!(
+                        "Failed to create BMS job for deal {} run {} piece {} URL {}: {:?}",
+                        piece_result.deal_id,
+                        piece_result.run_id,
+                        piece_result.piece_cid,
+                        piece_result.url_tested,
+                        error
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(stats)
+}
+
+fn map_deal_sli_error(error: DealSliServiceError) -> color_eyre::Report {
+    match error {
+        DealSliServiceError::InvalidRequest(message) => {
+            eyre!("Deal SLI invalid request: {message}")
+        }
+        DealSliServiceError::NotFound(message) => eyre!("Deal SLI target not found: {message}"),
+        DealSliServiceError::Internal(error) => error,
+    }
+}

--- a/url_finder/src/background/mod.rs
+++ b/url_finder/src/background/mod.rs
@@ -1,9 +1,11 @@
 mod bms_scheduler;
+mod deal_sli_scheduler;
 mod endpoint_scheduler;
 mod provider_discovery;
 mod url_discovery_scheduler;
 
 pub use bms_scheduler::*;
+pub use deal_sli_scheduler::*;
 pub use endpoint_scheduler::*;
 pub use provider_discovery::*;
 pub use url_discovery_scheduler::*;

--- a/url_finder/src/main.rs
+++ b/url_finder/src/main.rs
@@ -132,6 +132,44 @@ async fn main() -> Result<()> {
         }
     });
 
+    // Start the Deal SLI scheduler in the background
+    let deal_sli_scheduler_handle: JoinHandle<()> = tokio::spawn({
+        let config = config.clone();
+        let deal_sli_service = app_state.deal_sli_service.clone();
+        let deal_sli_repo = deal_sli_repo.clone();
+        let bms_client = bms_client.clone();
+        let bms_circuit_breaker = bms_circuit_breaker.clone();
+        let shutdown = shutdown_token.clone();
+        async move {
+            background::run_deal_sli_scheduler(
+                config,
+                deal_sli_service,
+                deal_sli_repo,
+                bms_client,
+                bms_circuit_breaker,
+                shutdown,
+            )
+            .await;
+        }
+    });
+
+    // Start the Deal SLI BMS result poller in the background
+    let deal_sli_bms_result_poller_handle: JoinHandle<()> = tokio::spawn({
+        let deal_sli_repo = deal_sli_repo.clone();
+        let bms_client = bms_client.clone();
+        let bms_circuit_breaker = bms_circuit_breaker.clone();
+        let shutdown = shutdown_token.clone();
+        async move {
+            background::run_deal_sli_bms_result_poller(
+                deal_sli_repo,
+                bms_client,
+                bms_circuit_breaker,
+                shutdown,
+            )
+            .await;
+        }
+    });
+
     let allowed_origins = ["https://sp-tool.allocator.tech".parse().unwrap()];
     let cors = CorsLayer::new()
         .allow_origin(allowed_origins)
@@ -158,6 +196,11 @@ async fn main() -> Result<()> {
         ("endpoint_scheduler", endpoint_scheduler_handle),
         ("url_discovery", url_discovery_handle),
         ("bms_scheduler", bms_scheduler_handle),
+        ("deal_sli_scheduler", deal_sli_scheduler_handle),
+        (
+            "deal_sli_bms_result_poller",
+            deal_sli_bms_result_poller_handle,
+        ),
     ];
 
     for (name, handle) in background_handles {

--- a/url_finder/src/repository/deal_sli_repo.rs
+++ b/url_finder/src/repository/deal_sli_repo.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, str::FromStr};
 
 use chrono::{DateTime, Utc};
 use color_eyre::{Result, eyre::eyre};
@@ -118,6 +118,7 @@ pub struct DealSliRunTarget {
 
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct DealSliLatestRun {
+    pub id: Uuid,
     pub deal_id: String,
     pub measurement_state: String,
     pub tested_at: Option<DateTime<Utc>>,
@@ -194,6 +195,60 @@ pub struct DealSliRunPieceSnapshot {
     pub piece_size_bytes: Option<BigDecimal>,
     pub manifest_snapshot_id: Option<Uuid>,
     pub file_size_bytes: Option<BigDecimal>,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct DealSliSuccessfulPieceResult {
+    pub run_id: Uuid,
+    pub deal_id: String,
+    pub piece_index: i32,
+    pub piece_cid: String,
+    pub url_tested: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewDealSliBmsJob {
+    pub deal_id: String,
+    pub run_id: Uuid,
+    pub piece_index: i32,
+    pub piece_cid: String,
+    pub bms_job_id: Uuid,
+    pub url_tested: String,
+    pub routing_key: String,
+    pub worker_count: i32,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct DealSliBmsJob {
+    pub id: Uuid,
+    pub deal_id: String,
+    pub run_id: Uuid,
+    pub piece_index: i32,
+    pub piece_cid: String,
+    pub bms_job_id: Uuid,
+    pub url_tested: String,
+    pub routing_key: String,
+    pub worker_count: i32,
+    pub status: String,
+    pub ping_avg_ms: Option<BigDecimal>,
+    pub head_avg_ms: Option<BigDecimal>,
+    pub ttfb_ms: Option<BigDecimal>,
+    pub download_speed_mbps: Option<BigDecimal>,
+    pub error_message: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DealSliBmsJobCompletion<'a> {
+    pub job_id: Uuid,
+    pub status: &'a str,
+    pub ping_avg_ms: Option<f64>,
+    pub head_avg_ms: Option<f64>,
+    pub ttfb_ms: Option<f64>,
+    pub download_speed_mbps: Option<f64>,
+    pub error_message: Option<&'a str>,
 }
 
 #[derive(Debug, sqlx::FromRow)]
@@ -314,6 +369,8 @@ impl DealSliRepository {
             })?;
             validate_measured_target_is_unchanged(target, &existing_target)?;
             validate_measured_pieces_are_unchanged(pieces, &existing_pieces)?;
+            self.ensure_target_schedule(&mut tx, &target.deal_id)
+                .await?;
             tx.commit().await?;
             return Ok(());
         }
@@ -448,7 +505,30 @@ impl DealSliRepository {
             .await?;
         }
 
+        self.ensure_target_schedule(&mut tx, &target.deal_id)
+            .await?;
+
         tx.commit().await?;
+        Ok(())
+    }
+
+    async fn ensure_target_schedule(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        deal_id: &str,
+    ) -> Result<()> {
+        sqlx::query!(
+            r#"INSERT INTO
+                    deal_sli_target_schedules (deal_id)
+               VALUES
+                    ($1)
+               ON CONFLICT (deal_id) DO NOTHING
+            "#,
+            deal_id
+        )
+        .execute(&mut **tx)
+        .await?;
+
         Ok(())
     }
 
@@ -550,6 +630,7 @@ impl DealSliRepository {
         Ok(sqlx::query_as!(
             DealSliLatestRun,
             r#"SELECT
+                    id,
                     deal_id,
                     measurement_state,
                     tested_at,
@@ -866,6 +947,7 @@ impl DealSliRepository {
         tx.commit().await?;
 
         Ok(DealSliLatestRun {
+            id: inserted.id,
             deal_id: inserted.deal_id,
             measurement_state: inserted.measurement_state,
             tested_at: inserted.tested_at,
@@ -890,6 +972,248 @@ impl DealSliRepository {
             failed_count: inserted.failed_count,
         })
     }
+
+    pub async fn claim_due_scheduled_targets(
+        &self,
+        limit: i64,
+        interval_days: i32,
+    ) -> Result<Vec<String>> {
+        Ok(sqlx::query_scalar!(
+            r#"WITH due AS (
+                    SELECT
+                        deal_id
+                    FROM
+                        deal_sli_target_schedules
+                    WHERE
+                        next_run_at <= NOW()
+                    ORDER BY
+                        next_run_at ASC,
+                        deal_id ASC
+                    LIMIT $1
+                    FOR UPDATE SKIP LOCKED
+                )
+                UPDATE
+                    deal_sli_target_schedules schedules
+                SET
+                    next_run_at = NOW() + make_interval(days => $2::int),
+                    updated_at = NOW()
+                FROM
+                    due
+                WHERE
+                    schedules.deal_id = due.deal_id
+                RETURNING
+                    schedules.deal_id
+            "#,
+            limit,
+            interval_days
+        )
+        .fetch_all(&self.pool)
+        .await?)
+    }
+
+    pub async fn get_successful_piece_results_without_bms_jobs(
+        &self,
+        run_id: Uuid,
+    ) -> Result<Vec<DealSliSuccessfulPieceResult>> {
+        Ok(sqlx::query_as!(
+            DealSliSuccessfulPieceResult,
+            r#"SELECT
+                    result.run_id,
+                    result.deal_id,
+                    result.piece_index,
+                    result.piece_cid,
+                    result.url_tested
+               FROM
+                    deal_sli_piece_results result
+               WHERE
+                    result.run_id = $1
+                    AND result.success
+                    AND NOT EXISTS (
+                        SELECT
+                            1
+                        FROM
+                            deal_sli_bms_jobs job
+                        WHERE
+                            job.run_id = result.run_id
+                            AND job.piece_index = result.piece_index
+                            AND job.url_tested = result.url_tested
+                    )
+               ORDER BY
+                    result.piece_index ASC,
+                    result.url_tested ASC
+            "#,
+            run_id
+        )
+        .fetch_all(&self.pool)
+        .await?)
+    }
+
+    pub async fn insert_deal_sli_bms_job(&self, job: &NewDealSliBmsJob) -> Result<DealSliBmsJob> {
+        Ok(sqlx::query_as!(
+            DealSliBmsJob,
+            r#"INSERT INTO
+                    deal_sli_bms_jobs (
+                        deal_id,
+                        run_id,
+                        piece_index,
+                        piece_cid,
+                        bms_job_id,
+                        url_tested,
+                        routing_key,
+                        worker_count,
+                        status
+                    )
+               VALUES
+                    ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+               ON CONFLICT (bms_job_id) DO UPDATE SET
+                    status = EXCLUDED.status
+               RETURNING
+                    id,
+                    deal_id,
+                    run_id,
+                    piece_index,
+                    piece_cid,
+                    bms_job_id,
+                    url_tested,
+                    routing_key,
+                    worker_count,
+                    status,
+                    ping_avg_ms,
+                    head_avg_ms,
+                    ttfb_ms,
+                    download_speed_mbps,
+                    error_message,
+                    created_at,
+                    completed_at
+            "#,
+            &job.deal_id,
+            job.run_id,
+            job.piece_index,
+            &job.piece_cid,
+            job.bms_job_id,
+            &job.url_tested,
+            &job.routing_key,
+            job.worker_count,
+            &job.status
+        )
+        .fetch_one(&self.pool)
+        .await?)
+    }
+
+    pub async fn get_pending_deal_sli_bms_jobs(&self) -> Result<Vec<DealSliBmsJob>> {
+        Ok(sqlx::query_as!(
+            DealSliBmsJob,
+            r#"SELECT
+                    id,
+                    deal_id,
+                    run_id,
+                    piece_index,
+                    piece_cid,
+                    bms_job_id,
+                    url_tested,
+                    routing_key,
+                    worker_count,
+                    status,
+                    ping_avg_ms,
+                    head_avg_ms,
+                    ttfb_ms,
+                    download_speed_mbps,
+                    error_message,
+                    created_at,
+                    completed_at
+               FROM
+                    deal_sli_bms_jobs
+               WHERE
+                    status = 'Pending'
+               ORDER BY
+                    created_at ASC,
+                    id ASC
+            "#
+        )
+        .fetch_all(&self.pool)
+        .await?)
+    }
+
+    pub async fn get_deal_sli_bms_jobs_for_run(&self, run_id: Uuid) -> Result<Vec<DealSliBmsJob>> {
+        Ok(sqlx::query_as!(
+            DealSliBmsJob,
+            r#"SELECT
+                    id,
+                    deal_id,
+                    run_id,
+                    piece_index,
+                    piece_cid,
+                    bms_job_id,
+                    url_tested,
+                    routing_key,
+                    worker_count,
+                    status,
+                    ping_avg_ms,
+                    head_avg_ms,
+                    ttfb_ms,
+                    download_speed_mbps,
+                    error_message,
+                    created_at,
+                    completed_at
+               FROM
+                    deal_sli_bms_jobs
+               WHERE
+                    run_id = $1
+               ORDER BY
+                    piece_index ASC,
+                    created_at ASC,
+                    id ASC
+            "#,
+            run_id
+        )
+        .fetch_all(&self.pool)
+        .await?)
+    }
+
+    pub async fn update_deal_sli_bms_job_completed(
+        &self,
+        update: &DealSliBmsJobCompletion<'_>,
+    ) -> Result<()> {
+        let ping = f64_to_bigdecimal(update.ping_avg_ms);
+        let head = f64_to_bigdecimal(update.head_avg_ms);
+        let ttfb = f64_to_bigdecimal(update.ttfb_ms);
+        let speed = f64_to_bigdecimal(update.download_speed_mbps);
+
+        let result = sqlx::query!(
+            r#"UPDATE
+                    deal_sli_bms_jobs
+               SET
+                    status = $2,
+                    ping_avg_ms = $3,
+                    head_avg_ms = $4,
+                    ttfb_ms = $5,
+                    download_speed_mbps = $6,
+                    error_message = $7,
+                    completed_at = NOW()
+               WHERE
+                    bms_job_id = $1
+            "#,
+            update.job_id,
+            update.status,
+            ping,
+            head,
+            ttfb,
+            speed,
+            update.error_message
+        )
+        .execute(&self.pool)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(eyre!("Deal SLI BMS job not found: {}", update.job_id));
+        }
+
+        Ok(())
+    }
+}
+
+fn f64_to_bigdecimal(value: Option<f64>) -> Option<BigDecimal> {
+    value.and_then(|v| BigDecimal::from_str(&v.to_string()).ok())
 }
 
 fn validate_measured_pieces_are_unchanged(

--- a/url_finder/src/services/deal_sli_service.rs
+++ b/url_finder/src/services/deal_sli_service.rs
@@ -5,14 +5,14 @@ use uuid::Uuid;
 
 use crate::{
     api::deals::{
-        DealLatestMeasurementResponse, DealManifestSnapshotResponse, DealPieceTarget,
-        DealSliRequirements, DealTargetResponse, DealTargetUpsertRequest, DealVersion,
-        MeasurementState,
+        DealBmsResultResponse, DealLatestMeasurementResponse, DealManifestSnapshotResponse,
+        DealPieceTarget, DealPorepSliResponse, DealSliRequirements, DealTargetResponse,
+        DealTargetUpsertRequest, DealVersion, MeasurementState,
     },
     config::Config,
     http_client::build_client,
     repository::{
-        DealSliLatestRun, DealSliManifestSnapshot, DealSliPiece, DealSliRepository,
+        DealSliBmsJob, DealSliLatestRun, DealSliManifestSnapshot, DealSliPiece, DealSliRepository,
         DealSliRequirementValues, DealSliRunPieceSnapshot, DealSliRunTarget,
         DealSliTargetWithPieces, NewCompletedDealSliRun, NewDealSliManifestSnapshot,
         NewDealSliPiece, NewDealSliPieceResult, NewDealSliTarget, StorageProviderRepository,
@@ -115,7 +115,10 @@ impl DealSliService {
 
         let latest = self.repo.get_latest_completed_run(deal_id).await?;
         Ok(match latest {
-            Some(run) => map_latest_response(run),
+            Some(run) => {
+                let bms_results = self.repo.get_deal_sli_bms_jobs_for_run(run.id).await?;
+                map_latest_response(run, bms_results)
+            }
             None => DealLatestMeasurementResponse::missing_with_piece_count(
                 deal_id.to_string(),
                 stored.pieces.len() as u32,
@@ -159,7 +162,7 @@ impl DealSliService {
             }
         };
 
-        Ok(map_latest_response(latest))
+        Ok(map_latest_response(latest, vec![]))
     }
 
     async fn run_cached_endpoint_measurement(
@@ -716,7 +719,13 @@ fn map_requirements(
     })
 }
 
-fn map_latest_response(run: DealSliLatestRun) -> DealLatestMeasurementResponse {
+fn map_latest_response(
+    run: DealSliLatestRun,
+    bms_results: Vec<DealSliBmsJob>,
+) -> DealLatestMeasurementResponse {
+    let porep_slis = map_porep_slis(&run, &bms_results);
+    let bms_results = bms_results.into_iter().map(map_bms_result).collect();
+
     DealLatestMeasurementResponse {
         deal_id: run.deal_id,
         measurement_state: MeasurementState::from_db_value(&run.measurement_state),
@@ -742,9 +751,108 @@ fn map_latest_response(run: DealSliLatestRun) -> DealLatestMeasurementResponse {
         is_reliable: run.is_reliable,
         result_code: run.result_code,
         error_code: run.error_code,
+        porep_slis,
+        bms_results,
         piece_count: run.piece_count as u32,
         success_count: run.success_count as u32,
         failed_count: run.failed_count as u32,
+    }
+}
+
+fn map_bms_result(result: DealSliBmsJob) -> DealBmsResultResponse {
+    DealBmsResultResponse {
+        piece_index: result.piece_index as u32,
+        piece_cid: result.piece_cid,
+        bms_job_id: result.bms_job_id.to_string(),
+        url_tested: result.url_tested,
+        routing_key: result.routing_key,
+        worker_count: result.worker_count as u32,
+        status: result.status,
+        ping_avg_ms: result.ping_avg_ms.as_ref().and_then(bigdecimal_to_f64),
+        head_avg_ms: result.head_avg_ms.as_ref().and_then(bigdecimal_to_f64),
+        ttfb_ms: result.ttfb_ms.as_ref().and_then(bigdecimal_to_f64),
+        download_speed_mbps: result
+            .download_speed_mbps
+            .as_ref()
+            .and_then(bigdecimal_to_f64),
+        error_message: result.error_message,
+        completed_at: result.completed_at,
+    }
+}
+
+fn map_porep_slis(run: &DealSliLatestRun, bms_results: &[DealSliBmsJob]) -> DealPorepSliResponse {
+    let retrievability_bps = run
+        .retrievability_percent
+        .as_ref()
+        .and_then(bigdecimal_to_f64)
+        .and_then(percent_to_bps);
+    let bandwidth_mbps =
+        min_completed_bms_metric(bms_results, |result| result.download_speed_mbps.as_ref())
+            .and_then(f64_floor_to_u32);
+    let latency_ms = max_completed_bms_metric(bms_results, |result| result.ttfb_ms.as_ref())
+        .and_then(f64_ceil_to_u32);
+
+    DealPorepSliResponse {
+        retrievability_bps,
+        bandwidth_mbps,
+        latency_ms,
+        indexing_pct: None,
+    }
+}
+
+fn min_completed_bms_metric<F>(results: &[DealSliBmsJob], metric: F) -> Option<f64>
+where
+    F: Fn(&DealSliBmsJob) -> Option<&BigDecimal> + 'static,
+{
+    completed_bms_values(results, metric).fold(None, |current, value| match current {
+        Some(existing) => Some(existing.min(value)),
+        None => Some(value),
+    })
+}
+
+fn max_completed_bms_metric<F>(results: &[DealSliBmsJob], metric: F) -> Option<f64>
+where
+    F: Fn(&DealSliBmsJob) -> Option<&BigDecimal> + 'static,
+{
+    completed_bms_values(results, metric).fold(None, |current, value| match current {
+        Some(existing) => Some(existing.max(value)),
+        None => Some(value),
+    })
+}
+
+fn completed_bms_values<F>(results: &[DealSliBmsJob], metric: F) -> impl Iterator<Item = f64> + '_
+where
+    F: Fn(&DealSliBmsJob) -> Option<&BigDecimal> + 'static,
+{
+    results
+        .iter()
+        .filter(|result| result.status == "Completed")
+        .filter_map(metric)
+        .filter_map(bigdecimal_to_f64)
+}
+
+fn percent_to_bps(value: f64) -> Option<u16> {
+    if !value.is_finite() || value < 0.0 {
+        return None;
+    }
+
+    let bps = (value * 100.0).round().clamp(0.0, 10_000.0);
+    Some(bps as u16)
+}
+
+fn f64_floor_to_u32(value: f64) -> Option<u32> {
+    if value.is_finite() && value >= 0.0 && value <= u32::MAX as f64 {
+        Some(value.floor() as u32)
+    } else {
+        None
+    }
+}
+
+fn f64_ceil_to_u32(value: f64) -> Option<u32> {
+    if value.is_finite() && value >= 0.0 && value <= u32::MAX as f64 {
+        Some(value.ceil() as u32)
+    } else {
+        None
     }
 }
 

--- a/url_finder/tests/integration_tests/deal_sli_scheduler.rs
+++ b/url_finder/tests/integration_tests/deal_sli_scheduler.rs
@@ -1,0 +1,605 @@
+use chrono::{DateTime, Utc};
+use serde_json::{Value, json};
+use std::sync::Arc;
+use url_finder::{
+    background::{
+        create_bms_circuit_breaker, run_deal_sli_bms_result_poller_once,
+        run_deal_sli_scheduler_once,
+    },
+    bms_client::BmsClient,
+    config::Config,
+    repository::{DealSliRepository, StorageProviderRepository},
+    services::deal_sli_service::DealSliService,
+};
+use uuid::Uuid;
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{body_partial_json, header, method, path},
+};
+
+use crate::common::*;
+
+#[derive(sqlx::FromRow)]
+struct StoredDealSliBmsJob {
+    deal_id: String,
+    run_id: Uuid,
+    piece_index: i32,
+    piece_cid: String,
+    bms_job_id: Uuid,
+    url_tested: String,
+    status: String,
+}
+
+#[derive(sqlx::FromRow)]
+struct StoredCompletedDealSliBmsJob {
+    status: String,
+    ping_avg_ms: Option<f64>,
+    head_avg_ms: Option<f64>,
+    ttfb_ms: Option<f64>,
+    download_speed_mbps: Option<f64>,
+    completed_at: Option<DateTime<Utc>>,
+}
+
+fn manifest_piece(piece_cid: &str, piece_size: u64, file_size: u64) -> Value {
+    json!({
+        "pieceType": "dag",
+        "pieceCid": piece_cid,
+        "pieceSize": piece_size,
+        "fileSize": file_size,
+        "rootCid": format!("bafy-{piece_cid}"),
+        "storagePath": format!("{piece_cid}.car")
+    })
+}
+
+async fn deal_request_with_manifest(ctx: &TestContext) -> Value {
+    let manifest = json!([{
+        "pieces": [
+            manifest_piece("baga6ea4seaq", 1024, 16_000_000_000),
+            manifest_piece("baga6ea4sear", 2048, 2048)
+        ]
+    }]);
+    let manifest_body = manifest.to_string();
+
+    Mock::given(method("GET"))
+        .and(path("/scheduler-manifest.json"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/json")
+                .set_body_string(manifest_body.clone()),
+        )
+        .mount(&ctx.mocks.piece_server)
+        .await;
+
+    json!({
+        "deal_version": "v2",
+        "provider_id": "1234",
+        "client": "5678",
+        "deal_size_bytes": "3072",
+        "manifest_hash": url_finder::services::deal_manifest::compute_manifest_hash(manifest_body.as_bytes()),
+        "manifest_location": format!("{}/scheduler-manifest.json", ctx.mocks.piece_server_url()),
+        "requirements": {
+            "retrievability_bps": 9500,
+            "bandwidth_mbps": 200,
+            "latency_ms": 150
+        }
+    })
+}
+
+#[tokio::test]
+async fn test_scheduler_runs_deal_sli_before_bms_and_links_successful_piece_jobs() {
+    let ctx = TestContext::new().await;
+    let request = deal_request_with_manifest(&ctx).await;
+
+    ctx.app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&request)
+        .await
+        .assert_status_ok();
+
+    ctx.mocks
+        .setup_piece_retrieval_mock("baga6ea4seaq", true)
+        .await;
+    ctx.mocks
+        .setup_piece_retrieval_mock("baga6ea4sear", false)
+        .await;
+    seed_provider_with_cached_endpoints(&ctx.dbs.app_pool, "1234", &[ctx.mocks.piece_server_url()])
+        .await;
+
+    let bms_mock = MockServer::start().await;
+    let bms_job_id = Uuid::new_v4();
+    Mock::given(method("POST"))
+        .and(path("/jobs"))
+        .and(header("content-type", "application/json"))
+        .and(body_partial_json(json!({
+            "url": format!("{}/piece/baga6ea4seaq", ctx.mocks.piece_server_url()),
+            "worker_count": 10
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": bms_job_id,
+            "status": "Pending",
+            "url": format!("{}/piece/baga6ea4seaq", ctx.mocks.piece_server_url()),
+            "routing_key": "us_east"
+        })))
+        .expect(1)
+        .mount(&bms_mock)
+        .await;
+
+    let mut config = Config::new_for_test(
+        "http://lotus.invalid".to_string(),
+        "http://cid.invalid".to_string(),
+    );
+    config.bms_url = bms_mock.uri();
+    let config = Arc::new(config);
+    let deal_sli_repo = Arc::new(DealSliRepository::new(ctx.dbs.app_pool.clone()));
+    let storage_provider_repo = Arc::new(StorageProviderRepository::new(ctx.dbs.app_pool.clone()));
+    let deal_sli_service = Arc::new(DealSliService::new(
+        deal_sli_repo.clone(),
+        storage_provider_repo,
+        config.clone(),
+    ));
+    let bms_client = Arc::new(BmsClient::new(config.bms_url.clone()));
+    let circuit_breaker = Arc::new(create_bms_circuit_breaker());
+
+    let stats = run_deal_sli_scheduler_once(
+        &config,
+        &deal_sli_service,
+        &deal_sli_repo,
+        &bms_client,
+        &circuit_breaker,
+    )
+    .await
+    .expect("scheduler tick should succeed");
+
+    assert_eq!(stats.targets_processed, 1);
+    assert_eq!(stats.bms_jobs_created, 1);
+
+    let rows = sqlx::query_as::<_, StoredDealSliBmsJob>(
+        r#"SELECT
+                deal_id,
+                run_id,
+                piece_index,
+                piece_cid,
+                bms_job_id,
+                url_tested,
+                status
+           FROM
+                deal_sli_bms_jobs
+           WHERE
+                deal_id = $1
+           ORDER BY
+                piece_index ASC
+        "#,
+    )
+    .bind("123")
+    .fetch_all(&ctx.dbs.app_pool)
+    .await
+    .expect("linked BMS jobs should load");
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].deal_id, "123");
+    assert_eq!(rows[0].piece_index, 0);
+    assert_eq!(rows[0].piece_cid, "baga6ea4seaq");
+    assert_eq!(rows[0].bms_job_id, bms_job_id);
+    assert!(rows[0].url_tested.ends_with("/piece/baga6ea4seaq"));
+    assert_eq!(rows[0].status, "Pending");
+
+    let linked_run_piece_count: i64 = sqlx::query_scalar(
+        r#"SELECT
+                COUNT(*)
+           FROM
+                deal_sli_piece_results
+           WHERE
+                run_id = $1
+                AND piece_cid = $2
+                AND success
+        "#,
+    )
+    .bind(rows[0].run_id)
+    .bind(&rows[0].piece_cid)
+    .fetch_one(&ctx.dbs.app_pool)
+    .await
+    .expect("linked run piece result should load");
+    assert_eq!(linked_run_piece_count, 1);
+
+    let second_stats = run_deal_sli_scheduler_once(
+        &config,
+        &deal_sli_service,
+        &deal_sli_repo,
+        &bms_client,
+        &circuit_breaker,
+    )
+    .await
+    .expect("second scheduler tick should succeed");
+
+    assert_eq!(second_stats.targets_processed, 0);
+    assert_eq!(second_stats.bms_jobs_created, 0);
+}
+
+#[tokio::test]
+async fn test_deal_sli_bms_result_poller_stores_completed_job_metrics() {
+    let ctx = TestContext::new().await;
+    let request = deal_request_with_manifest(&ctx).await;
+
+    ctx.app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&request)
+        .await
+        .assert_status_ok();
+
+    ctx.mocks
+        .setup_piece_retrieval_mock("baga6ea4seaq", true)
+        .await;
+    ctx.mocks
+        .setup_piece_retrieval_mock("baga6ea4sear", false)
+        .await;
+    seed_provider_with_cached_endpoints(&ctx.dbs.app_pool, "1234", &[ctx.mocks.piece_server_url()])
+        .await;
+
+    let bms_mock = MockServer::start().await;
+    let bms_job_id = Uuid::new_v4();
+    let subjob_id = Uuid::new_v4();
+    Mock::given(method("POST"))
+        .and(path("/jobs"))
+        .and(header("content-type", "application/json"))
+        .and(body_partial_json(json!({
+            "url": format!("{}/piece/baga6ea4seaq", ctx.mocks.piece_server_url()),
+            "worker_count": 10
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": bms_job_id,
+            "status": "Pending",
+            "url": format!("{}/piece/baga6ea4seaq", ctx.mocks.piece_server_url()),
+            "routing_key": "us_east"
+        })))
+        .expect(1)
+        .mount(&bms_mock)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!("/jobs/{bms_job_id}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": bms_job_id,
+            "status": "Completed",
+            "url": format!("{}/piece/baga6ea4seaq", ctx.mocks.piece_server_url()),
+            "routing_key": "us_east",
+            "details": {
+                "worker_count": 10,
+                "size_mb": 15
+            },
+            "sub_jobs": [
+                {
+                    "id": subjob_id,
+                    "status": "Completed",
+                    "worker_data": [
+                        {
+                            "ping": {"avg": 0.025, "min": 0.020, "max": 0.030},
+                            "head": {"avg": 50.0, "min": 45.0, "max": 55.0},
+                            "download": {
+                                "download_speed": 500.0,
+                                "time_to_first_byte_ms": 100.0,
+                                "total_bytes": 104857600,
+                                "elapsed_secs": 10.0
+                            }
+                        }
+                    ]
+                }
+            ]
+        })))
+        .expect(1)
+        .mount(&bms_mock)
+        .await;
+
+    let mut config = Config::new_for_test(
+        "http://lotus.invalid".to_string(),
+        "http://cid.invalid".to_string(),
+    );
+    config.bms_url = bms_mock.uri();
+    let config = Arc::new(config);
+    let deal_sli_repo = Arc::new(DealSliRepository::new(ctx.dbs.app_pool.clone()));
+    let storage_provider_repo = Arc::new(StorageProviderRepository::new(ctx.dbs.app_pool.clone()));
+    let deal_sli_service = Arc::new(DealSliService::new(
+        deal_sli_repo.clone(),
+        storage_provider_repo,
+        config.clone(),
+    ));
+    let bms_client = Arc::new(BmsClient::new(config.bms_url.clone()));
+    let circuit_breaker = Arc::new(create_bms_circuit_breaker());
+
+    run_deal_sli_scheduler_once(
+        &config,
+        &deal_sli_service,
+        &deal_sli_repo,
+        &bms_client,
+        &circuit_breaker,
+    )
+    .await
+    .expect("scheduler tick should create a pending BMS job");
+
+    run_deal_sli_bms_result_poller_once(&deal_sli_repo, &bms_client, &circuit_breaker)
+        .await
+        .expect("result poller should store completed metrics");
+    run_deal_sli_bms_result_poller_once(&deal_sli_repo, &bms_client, &circuit_breaker)
+        .await
+        .expect("result poller should be idempotent after completion");
+
+    let row = sqlx::query_as::<_, StoredCompletedDealSliBmsJob>(
+        r#"SELECT
+                status,
+                ping_avg_ms::float8 AS ping_avg_ms,
+                head_avg_ms::float8 AS head_avg_ms,
+                ttfb_ms::float8 AS ttfb_ms,
+                download_speed_mbps::float8 AS download_speed_mbps,
+                completed_at
+           FROM
+                deal_sli_bms_jobs
+           WHERE
+                bms_job_id = $1
+        "#,
+    )
+    .bind(bms_job_id)
+    .fetch_one(&ctx.dbs.app_pool)
+    .await
+    .expect("completed BMS job should load");
+
+    assert_eq!(row.status, "Completed");
+    assert_eq!(row.ping_avg_ms, Some(25.0));
+    assert_eq!(row.head_avg_ms, Some(50.0));
+    assert_eq!(row.ttfb_ms, Some(100.0));
+    assert_eq!(row.download_speed_mbps, Some(500.0));
+    assert!(row.completed_at.is_some());
+
+    let latest_response = ctx.app.get("/deals/123/latest").await;
+    latest_response.assert_status_ok();
+    let latest_body: Value = latest_response.json();
+    assert_json_diff::assert_json_include!(
+        actual: latest_body,
+        expected: json!({
+            "porep_slis": {
+                "retrievability_bps": 5000,
+                "bandwidth_mbps": 500,
+                "latency_ms": 100,
+                "indexing_pct": null
+            },
+            "bms_results": [
+                {
+                    "piece_index": 0,
+                    "piece_cid": "baga6ea4seaq",
+                    "bms_job_id": bms_job_id.to_string(),
+                    "url_tested": format!("{}/piece/baga6ea4seaq", ctx.mocks.piece_server_url()),
+                    "routing_key": "us_east",
+                    "worker_count": 10,
+                    "status": "Completed",
+                    "ping_avg_ms": 25.0,
+                    "head_avg_ms": 50.0,
+                    "ttfb_ms": 100.0,
+                    "download_speed_mbps": 500.0,
+                    "error_message": null
+                }
+            ]
+        })
+    );
+    assert!(
+        latest_body["bms_results"][0]
+            .get("completed_at")
+            .and_then(Value::as_str)
+            .is_some(),
+        "completed BMS result should include completed_at"
+    );
+}
+
+#[tokio::test]
+async fn test_deal_sli_bms_result_poller_stores_failed_or_cancelled_job_without_fake_metrics() {
+    for terminal_status in ["Failed", "Cancelled"] {
+        let ctx = TestContext::new().await;
+        let request = deal_request_with_manifest(&ctx).await;
+
+        ctx.app
+            .put("/deals/123")
+            .authorization_bearer("test-token")
+            .json(&request)
+            .await
+            .assert_status_ok();
+
+        ctx.mocks
+            .setup_piece_retrieval_mock("baga6ea4seaq", true)
+            .await;
+        ctx.mocks
+            .setup_piece_retrieval_mock("baga6ea4sear", false)
+            .await;
+        seed_provider_with_cached_endpoints(
+            &ctx.dbs.app_pool,
+            "1234",
+            &[ctx.mocks.piece_server_url()],
+        )
+        .await;
+
+        let bms_mock = MockServer::start().await;
+        let bms_job_id = Uuid::new_v4();
+        Mock::given(method("POST"))
+            .and(path("/jobs"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": bms_job_id,
+                "status": "Pending",
+                "url": format!("{}/piece/baga6ea4seaq", ctx.mocks.piece_server_url()),
+                "routing_key": "us_east"
+            })))
+            .expect(1)
+            .mount(&bms_mock)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!("/jobs/{bms_job_id}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": bms_job_id,
+                "status": terminal_status,
+                "url": format!("{}/piece/baga6ea4seaq", ctx.mocks.piece_server_url()),
+                "routing_key": "us_east",
+                "details": null,
+                "sub_jobs": []
+            })))
+            .expect(1)
+            .mount(&bms_mock)
+            .await;
+
+        let mut config = Config::new_for_test(
+            "http://lotus.invalid".to_string(),
+            "http://cid.invalid".to_string(),
+        );
+        config.bms_url = bms_mock.uri();
+        let config = Arc::new(config);
+        let deal_sli_repo = Arc::new(DealSliRepository::new(ctx.dbs.app_pool.clone()));
+        let storage_provider_repo =
+            Arc::new(StorageProviderRepository::new(ctx.dbs.app_pool.clone()));
+        let deal_sli_service = Arc::new(DealSliService::new(
+            deal_sli_repo.clone(),
+            storage_provider_repo,
+            config.clone(),
+        ));
+        let bms_client = Arc::new(BmsClient::new(config.bms_url.clone()));
+        let circuit_breaker = Arc::new(create_bms_circuit_breaker());
+
+        run_deal_sli_scheduler_once(
+            &config,
+            &deal_sli_service,
+            &deal_sli_repo,
+            &bms_client,
+            &circuit_breaker,
+        )
+        .await
+        .expect("scheduler tick should create a pending BMS job");
+        run_deal_sli_bms_result_poller_once(&deal_sli_repo, &bms_client, &circuit_breaker)
+            .await
+            .expect("result poller should store terminal status");
+
+        let latest_response = ctx.app.get("/deals/123/latest").await;
+        latest_response.assert_status_ok();
+        let latest_body: Value = latest_response.json();
+        assert_json_diff::assert_json_include!(
+            actual: latest_body,
+            expected: json!({
+                "porep_slis": {
+                    "retrievability_bps": 5000,
+                    "bandwidth_mbps": null,
+                    "latency_ms": null,
+                    "indexing_pct": null
+                },
+                "bms_results": [
+                    {
+                        "bms_job_id": bms_job_id.to_string(),
+                        "status": terminal_status,
+                        "ping_avg_ms": null,
+                        "head_avg_ms": null,
+                        "ttfb_ms": null,
+                        "download_speed_mbps": null
+                    }
+                ]
+            })
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_deal_sli_bms_result_poller_marks_stale_pending_job_timeout() {
+    let ctx = TestContext::new().await;
+    let request = deal_request_with_manifest(&ctx).await;
+
+    ctx.app
+        .put("/deals/123")
+        .authorization_bearer("test-token")
+        .json(&request)
+        .await
+        .assert_status_ok();
+
+    ctx.mocks
+        .setup_piece_retrieval_mock("baga6ea4seaq", true)
+        .await;
+    ctx.mocks
+        .setup_piece_retrieval_mock("baga6ea4sear", false)
+        .await;
+    seed_provider_with_cached_endpoints(&ctx.dbs.app_pool, "1234", &[ctx.mocks.piece_server_url()])
+        .await;
+
+    let bms_mock = MockServer::start().await;
+    let bms_job_id = Uuid::new_v4();
+    Mock::given(method("POST"))
+        .and(path("/jobs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": bms_job_id,
+            "status": "Pending",
+            "url": format!("{}/piece/baga6ea4seaq", ctx.mocks.piece_server_url()),
+            "routing_key": "us_east"
+        })))
+        .expect(1)
+        .mount(&bms_mock)
+        .await;
+
+    let mut config = Config::new_for_test(
+        "http://lotus.invalid".to_string(),
+        "http://cid.invalid".to_string(),
+    );
+    config.bms_url = bms_mock.uri();
+    let config = Arc::new(config);
+    let deal_sli_repo = Arc::new(DealSliRepository::new(ctx.dbs.app_pool.clone()));
+    let storage_provider_repo = Arc::new(StorageProviderRepository::new(ctx.dbs.app_pool.clone()));
+    let deal_sli_service = Arc::new(DealSliService::new(
+        deal_sli_repo.clone(),
+        storage_provider_repo,
+        config.clone(),
+    ));
+    let bms_client = Arc::new(BmsClient::new(config.bms_url.clone()));
+    let circuit_breaker = Arc::new(create_bms_circuit_breaker());
+
+    run_deal_sli_scheduler_once(
+        &config,
+        &deal_sli_service,
+        &deal_sli_repo,
+        &bms_client,
+        &circuit_breaker,
+    )
+    .await
+    .expect("scheduler tick should create a pending BMS job");
+
+    sqlx::query(
+        r#"UPDATE
+                deal_sli_bms_jobs
+           SET
+                created_at = NOW() - INTERVAL '49 hours'
+           WHERE
+                bms_job_id = $1
+        "#,
+    )
+    .bind(bms_job_id)
+    .execute(&ctx.dbs.app_pool)
+    .await
+    .expect("pending job should be made stale");
+
+    run_deal_sli_bms_result_poller_once(&deal_sli_repo, &bms_client, &circuit_breaker)
+        .await
+        .expect("result poller should mark stale jobs timed out");
+
+    let row = sqlx::query_as::<_, StoredCompletedDealSliBmsJob>(
+        r#"SELECT
+                status,
+                ping_avg_ms::float8 AS ping_avg_ms,
+                head_avg_ms::float8 AS head_avg_ms,
+                ttfb_ms::float8 AS ttfb_ms,
+                download_speed_mbps::float8 AS download_speed_mbps,
+                completed_at
+           FROM
+                deal_sli_bms_jobs
+           WHERE
+                bms_job_id = $1
+        "#,
+    )
+    .bind(bms_job_id)
+    .fetch_one(&ctx.dbs.app_pool)
+    .await
+    .expect("timed out BMS job should load");
+
+    assert_eq!(row.status, "Timeout");
+    assert!(row.ping_avg_ms.is_none());
+    assert!(row.head_avg_ms.is_none());
+    assert!(row.ttfb_ms.is_none());
+    assert!(row.download_speed_mbps.is_none());
+    assert!(row.completed_at.is_some());
+}

--- a/url_finder/tests/integration_tests/mod.rs
+++ b/url_finder/tests/integration_tests/mod.rs
@@ -2,6 +2,7 @@ pub mod bms_client;
 pub mod bms_result_repo;
 pub mod clients_providers;
 pub mod deal_sli_api;
+pub mod deal_sli_scheduler;
 pub mod deals_auth;
 pub mod extended_response;
 pub mod find_client;


### PR DESCRIPTION
This adds the scheduler slice on top of the manifest-backed Deal SLI API. It runs due Deal SLI targets, links successful piece URLs to BMS jobs, and exposes completed BMS metrics in the latest deal state.

Changes:
- add Deal SLI target schedules and BMS job storage
- run due Deal SLI targets from the background scheduler
- create BMS jobs for successful piece URLs and poll terminal job results
- return `porep_slis` and `bms_results` from `/deals/{deal_id}/latest`
- update README, `.env.example`, and Swagger docs for the PoRep Market Deal SLI API