### PR TITLE
Use Keccak-256 for manifest hashes

### DIFF
--- a/url_finder/src/api/deals/types.rs
+++ b/url_finder/src/api/deals/types.rs
@@ -111,7 +111,7 @@ pub struct DealTargetUpsertRequest {
     /// Deal size in bytes, serialized as a base-10 integer string.
     #[schema(example = "7112600059904")]
     pub deal_size_bytes: String,
-    /// Expected SHA-256 hash of the manifest body. A leading `0x` is accepted.
+    /// Expected Keccak-256 hash of the manifest body. A leading `0x` is accepted.
     #[schema(example = "43ff1a93b66d742e9f9efc3305acaa51c9297b7000145f35e968e2b42e7bf328")]
     pub manifest_hash: String,
     /// HTTP or HTTPS URL of the PoRep manifest to fetch and snapshot.

--- a/url_finder/src/api/providers/get_client_providers.rs
+++ b/url_finder/src/api/providers/get_client_providers.rs
@@ -77,7 +77,7 @@ pub async fn handle_get_client_providers(
     if providers_data.is_empty() {
         return Err(not_found_with_code(
             ErrorCode::NotFound,
-            format!("Client {} has no providers", &path.id),
+            format!("Client {} has no providers", path.id),
         ));
     }
 

--- a/url_finder/src/api/providers/get_provider.rs
+++ b/url_finder/src/api/providers/get_provider.rs
@@ -65,7 +65,7 @@ pub async fn handle_get_provider(
         .ok_or_else(|| {
             not_found_with_code(
                 ErrorCode::NotFound,
-                format!("Provider {} not found", &path.id),
+                format!("Provider {} not found", path.id),
             )
         })?;
 

--- a/url_finder/src/api/providers/get_provider_client.rs
+++ b/url_finder/src/api/providers/get_provider_client.rs
@@ -86,7 +86,7 @@ pub async fn handle_get_provider_client(
                 ErrorCode::NotFound,
                 format!(
                     "Provider {} with client {} not found",
-                    &path.id, &path.client_id
+                    path.id, path.client_id
                 ),
             )
         })?;

--- a/url_finder/src/api/providers/reset_provider.rs
+++ b/url_finder/src/api/providers/reset_provider.rs
@@ -105,7 +105,7 @@ pub async fn handle_reset_provider(
         .ok_or_else(|| {
             not_found_with_code(
                 ErrorCode::NotFound,
-                format!("Provider {} not found", &path.id),
+                format!("Provider {} not found", path.id),
             )
         })?;
 

--- a/url_finder/src/services/deal_manifest.rs
+++ b/url_finder/src/services/deal_manifest.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 use std::{net::IpAddr, str};
 
+use alloy::primitives::keccak256;
 use color_eyre::{
     Result,
     eyre::{Context, eyre},
@@ -8,7 +9,6 @@ use color_eyre::{
 use futures::StreamExt;
 use reqwest::Url;
 use serde_json::Value;
-use sha2::{Digest, Sha256};
 use sqlx::types::BigDecimal;
 
 const MAX_MANIFEST_BYTES: usize = 10 * 1024 * 1024;
@@ -157,9 +157,7 @@ async fn read_manifest_body(
 }
 
 pub fn compute_manifest_hash(bytes: &[u8]) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    hex::encode(hasher.finalize())
+    hex::encode(keccak256(bytes))
 }
 
 pub fn manifest_hash_matches(expected_hash: &str, bytes: &[u8]) -> bool {
@@ -313,9 +311,9 @@ mod tests {
     }
 
     #[test]
-    fn verifies_sha256_manifest_hash_with_optional_0x_prefix() {
+    fn verifies_keccak256_manifest_hash_with_optional_0x_prefix() {
         let raw = br#"[{"pieces":[]}]"#;
-        let expected = compute_manifest_hash(raw);
+        let expected = "0f736d80eccc8276fe81992e0d2b64a1203d45b902fa3c9ea1956c19f1c0b876";
 
         assert!(manifest_hash_matches(&expected, raw));
         assert!(manifest_hash_matches(&format!("0x{expected}"), raw));


### PR DESCRIPTION
## Why

PoRep Market V2 uses Keccak-256 over raw manifest bytes. URL Finder used SHA-256, so the hashes did not match.

## What changed

- Calculate manifest hashes with Keccak-256
- Update the OpenAPI description
- Add a regression test for the expected hash